### PR TITLE
feat(phase-1): implement core runtime packages

### DIFF
--- a/examples/phase1-demo/README.md
+++ b/examples/phase1-demo/README.md
@@ -1,0 +1,103 @@
+# Phase 1 Demo
+
+This example demonstrates the Phase 1 core runtime deliverables:
+
+## Features Demonstrated
+
+1. **Import Maps** - Browser-native module resolution
+2. **__fePreload Runtime** - Dynamic import handling with caching
+3. **fe: Specifiers** - Custom specifier scheme for platform modules
+4. **Module Loading** - Demonstrates loading an MFE via `fe:@demo/hello`
+
+## Running the Demo
+
+### Option 1: Local Server
+
+```bash
+# Using Python
+python3 -m http.server 8000
+
+# Using Bun
+bun --hot examples/phase1-demo/index.html
+
+# Using Node.js
+npx serve examples/phase1-demo
+```
+
+Then open http://localhost:8000 in your browser.
+
+### Option 2: Direct File
+
+Some browsers allow opening the HTML file directly, but import maps require a server context.
+
+## What's Happening
+
+### Import Map
+
+The import map defines how `fe:` specifiers resolve to URLs:
+
+```json
+{
+  "imports": {
+    "fe:@demo/hello": "./mfe-hello.js",
+    "fe:state": "https://esm.sh/@ungap/global-this@0.4.4",
+    "fe:routing": "https://esm.sh/@ungap/global-this@0.4.4"
+  }
+}
+```
+
+### __fePreload Runtime
+
+The `__fePreload` function:
+
+1. Checks module cache
+2. Prevents duplicate loads
+3. Uses native `import()` with specifiers
+4. Tracks loading state and errors
+5. Provides cache inspection
+
+### Loading Flow
+
+```
+Click "Load Mock MFE"
+    ↓
+window.__fePreload("fe:@demo/hello")
+    ↓
+Check cache (miss)
+    ↓
+import("fe:@demo/hello")
+    ↓
+Browser resolves via import map → "./mfe-hello.js"
+    ↓
+Module loads and executes
+    ↓
+Cache result
+    ↓
+Return exports to caller
+```
+
+## Browser Requirements
+
+- ES Modules support
+- Import Maps support (Chrome 89+, Safari 16.4+, Firefox 108+)
+- Dynamic import() support
+
+For older browsers, use [es-module-shims](https://github.com/guybedford/es-module-shims).
+
+## Phase 1 Exit Criteria
+
+This demo verifies:
+
+✓ Import maps work in browser
+✓ fe: specifiers resolve to URLs
+✓ __fePreload handles dynamic imports
+✓ Module caching works
+✓ Error handling works
+✓ Can load an MFE via fe: specifier
+
+## Next Steps (Phase 2+)
+
+- CLI commands (fe init, fe dev)
+- Build pipeline and bundling
+- Registry and source publishing
+- Full NATIVERS platform packages

--- a/examples/phase1-demo/index.html
+++ b/examples/phase1-demo/index.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FE Platform - Phase 1 Demo</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 2rem;
+        line-height: 1.6;
+      }
+      h1 {
+        color: #333;
+      }
+      .status {
+        padding: 1rem;
+        margin: 1rem 0;
+        border-radius: 4px;
+        background: #f0f0f0;
+      }
+      .success {
+        background: #d4edda;
+        color: #155724;
+      }
+      .error {
+        background: #f8d7da;
+        color: #721c24;
+      }
+      button {
+        padding: 0.5rem 1rem;
+        margin: 0.5rem 0.5rem 0.5rem 0;
+        border: none;
+        border-radius: 4px;
+        background: #007bff;
+        color: white;
+        cursor: pointer;
+      }
+      button:hover {
+        background: #0056b3;
+      }
+      pre {
+        background: #f5f5f5;
+        padding: 1rem;
+        border-radius: 4px;
+        overflow-x: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>FE Platform - Phase 1 Demo</h1>
+    <p>
+      This demo showcases Phase 1 core runtime features:
+    </p>
+    <ul>
+      <li>Import maps for fe: specifier resolution</li>
+      <li>__fePreload runtime for dynamic imports</li>
+      <li>Module loading and caching</li>
+    </ul>
+
+    <h2>Actions</h2>
+    <div>
+      <button onclick="loadMockMFE()">Load Mock MFE</button>
+      <button onclick="showCache()">Show Module Cache</button>
+      <button onclick="showStats()">Show Statistics</button>
+      <button onclick="clearCache()">Clear Cache</button>
+    </div>
+
+    <h2>Status</h2>
+    <div id="status" class="status">
+      Ready. Click "Load Mock MFE" to test dynamic loading.
+    </div>
+
+    <h2>Import Map</h2>
+    <pre id="import-map"></pre>
+
+    <!-- Import Map Definition -->
+    <script type="importmap">
+      {
+        "imports": {
+          "fe:@demo/hello": "./mfe-hello.js",
+          "fe:state": "https://esm.sh/@ungap/global-this@0.4.4",
+          "fe:routing": "https://esm.sh/@ungap/global-this@0.4.4"
+        }
+      }
+    </script>
+
+    <!-- __fePreload Runtime (inline for demo) -->
+    <script type="module">
+      // Install __fePreload runtime
+      window.__fePreload = (function () {
+        const moduleCache = new Map();
+        const loadingPromises = new Map();
+
+        async function __fePreload(specifier) {
+          const cached = moduleCache.get(specifier);
+          if (cached?.state === "loaded") {
+            return cached.exports;
+          }
+          if (cached?.state === "error") {
+            throw cached.error;
+          }
+
+          if (loadingPromises.has(specifier)) {
+            return loadingPromises.get(specifier);
+          }
+
+          const loadPromise = (async () => {
+            const entry = {
+              specifier,
+              url: specifier,
+              exports: null,
+              loadedAt: Date.now(),
+              state: "loading",
+            };
+            moduleCache.set(specifier, entry);
+
+            try {
+              const module = await import(specifier);
+              entry.exports = module;
+              entry.state = "loaded";
+              entry.loadedAt = Date.now();
+              return module;
+            } catch (error) {
+              entry.state = "error";
+              entry.error = error;
+              throw error;
+            }
+          })();
+
+          loadingPromises.set(specifier, loadPromise);
+          try {
+            return await loadPromise;
+          } finally {
+            loadingPromises.delete(specifier);
+          }
+        }
+
+        __fePreload.getCache = () => new Map(moduleCache);
+        __fePreload.isLoaded = (specifier) =>
+          moduleCache.get(specifier)?.state === "loaded";
+        __fePreload.clearCache = () => {
+          moduleCache.clear();
+          loadingPromises.clear();
+        };
+        __fePreload.getStats = () => {
+          let loaded = 0,
+            loading = 0,
+            errors = 0;
+          for (const entry of moduleCache.values()) {
+            if (entry.state === "loaded") loaded++;
+            else if (entry.state === "loading") loading++;
+            else if (entry.state === "error") errors++;
+          }
+          return { total: moduleCache.size, loaded, loading, errors };
+        };
+
+        return __fePreload;
+      })();
+
+      // Display import map
+      const importMapScript = document.querySelector(
+        'script[type="importmap"]'
+      );
+      if (importMapScript) {
+        document.getElementById("import-map").textContent =
+          importMapScript.textContent;
+      }
+
+      // Demo functions
+      window.loadMockMFE = async function () {
+        const status = document.getElementById("status");
+        status.className = "status";
+        status.textContent = "Loading fe:@demo/hello...";
+
+        try {
+          const module = await __fePreload("fe:@demo/hello");
+          status.className = "status success";
+          status.textContent = `✓ Successfully loaded MFE!\n\nExports: ${JSON.stringify(
+            Object.keys(module),
+            null,
+            2
+          )}`;
+        } catch (error) {
+          status.className = "status error";
+          status.textContent = `✗ Failed to load MFE: ${error.message}\n\nNote: This demo needs mfe-hello.js to exist. The important part is that __fePreload and import maps are working.`;
+        }
+      };
+
+      window.showCache = function () {
+        const cache = __fePreload.getCache();
+        const status = document.getElementById("status");
+        status.className = "status";
+
+        if (cache.size === 0) {
+          status.textContent = "Module cache is empty.";
+          return;
+        }
+
+        const entries = Array.from(cache.entries())
+          .map(
+            ([specifier, entry]) =>
+              `${specifier}\n  State: ${entry.state}\n  Loaded: ${new Date(
+                entry.loadedAt
+              ).toLocaleTimeString()}`
+          )
+          .join("\n\n");
+
+        status.textContent = `Module Cache (${cache.size} entries):\n\n${entries}`;
+      };
+
+      window.showStats = function () {
+        const stats = __fePreload.getStats();
+        const status = document.getElementById("status");
+        status.className = "status";
+        status.textContent = `Statistics:\n\nTotal modules: ${stats.total}\nLoaded: ${stats.loaded}\nLoading: ${stats.loading}\nErrors: ${stats.errors}`;
+      };
+
+      window.clearCache = function () {
+        __fePreload.clearCache();
+        const status = document.getElementById("status");
+        status.className = "status success";
+        status.textContent = "✓ Module cache cleared.";
+      };
+
+      console.log("✓ __fePreload runtime installed");
+      console.log("✓ Import map loaded");
+      console.log(
+        "Ready to load MFEs using fe: specifiers"
+      );
+    </script>
+  </body>
+</html>

--- a/examples/phase1-demo/mfe-hello.js
+++ b/examples/phase1-demo/mfe-hello.js
@@ -1,0 +1,44 @@
+/**
+ * Mock MFE for Phase 1 demo
+ * Demonstrates a simple micro-frontend that can be loaded via fe: specifier
+ */
+
+export const name = "@demo/hello";
+export const version = "1.0.0";
+
+export function greet(name = "World") {
+  return `Hello, ${name}! from MFE @demo/hello`;
+}
+
+export function mount(container) {
+  if (typeof container === "string") {
+    container = document.querySelector(container);
+  }
+
+  if (!container) {
+    throw new Error("Container not found");
+  }
+
+  container.innerHTML = `
+    <div style="padding: 1rem; border: 2px solid #007bff; border-radius: 4px; background: #e7f3ff;">
+      <h3>Mock MFE: @demo/hello</h3>
+      <p>${greet()}</p>
+      <p><small>Version: ${version}</small></p>
+    </div>
+  `;
+
+  return {
+    unmount() {
+      container.innerHTML = "";
+    },
+  };
+}
+
+export default {
+  name,
+  version,
+  greet,
+  mount,
+};
+
+console.log(`[${name}] MFE loaded successfully`);

--- a/packages/core/config/README.md
+++ b/packages/core/config/README.md
@@ -1,0 +1,134 @@
+# @fe/config
+
+Configuration provider abstraction for the FE platform.
+
+## Purpose
+
+Provides a unified interface for reading and writing platform configuration from various backends. All configuration is JSON-only (ADR-018).
+
+## Phase 1 Implementation
+
+This package currently includes:
+- `ConfigProvider` interface
+- File-based provider (`file://`)
+- Configuration types for platform.json, environments.json, rollout.json, governance.json
+- Utility functions for config manipulation
+
+## Usage
+
+### Creating a File Provider
+
+```typescript
+import { createFileProvider } from "@fe/config";
+
+const provider = createFileProvider("file:///path/to/config");
+```
+
+### Reading Configuration
+
+```typescript
+// Get entire namespace
+const platform = await provider.getAll("platform");
+
+// Get specific value by path
+const name = await provider.get("platform.name");
+const registryUrl = await provider.get("platform.registry.url");
+```
+
+### Writing Configuration
+
+```typescript
+// Set entire namespace
+await provider.setAll("platform", {
+  name: "my-platform",
+  version: "1.0.0",
+  org: "myorg"
+});
+
+// Set specific value by path
+await provider.set("platform.registry.url", "https://registry.example.com");
+```
+
+### Checking Availability
+
+```typescript
+if (await provider.isAvailable()) {
+  // Provider is accessible
+}
+```
+
+## Configuration Types
+
+### PlatformConfig
+
+```typescript
+interface PlatformConfig {
+  name: string;
+  version: string;
+  org: string;
+  registry?: {
+    url: string;
+    source?: string;
+    build?: string;
+  };
+}
+```
+
+### EnvironmentsConfig
+
+```typescript
+interface EnvironmentsConfig {
+  environments: Array<{
+    name: string;
+    url: string;
+    cdnUrl?: string;
+  }>;
+}
+```
+
+### RolloutConfig
+
+```typescript
+interface RolloutConfig {
+  states: Array<{
+    mfeName: string;
+    environment: string;
+    rolledOut: string;
+    rollingOut?: {
+      version: string;
+      percentage: number;
+    };
+  }>;
+}
+```
+
+### GovernanceConfig
+
+```typescript
+interface GovernanceConfig {
+  scoring?: {
+    bundleSize?: { maxKb: number; weight: number };
+    coverage?: { minPercent: number; weight: number };
+    accessibility?: { minScore: number; weight: number };
+  };
+  permissions?: {
+    allowedScopes?: string[];
+    checksumVerification?: boolean;
+  };
+}
+```
+
+## Future Providers (Phase 13)
+
+- `s3://` - AWS S3
+- `consul://` - HashiCorp Consul
+- `etcd://` - etcd
+- `postgres://` - PostgreSQL
+- `http://` / `https://` - HTTP API
+
+## Design Principles
+
+1. **JSON-only**: No code execution in configuration (ADR-018)
+2. **Provider abstraction**: Swap backends without changing code (ADR-019)
+3. **Dot notation**: Access nested values with "key.nested.value" paths
+4. **Validation**: All values must be JSON-serializable

--- a/packages/core/config/package.json
+++ b/packages/core/config/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@fe/config",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "bun ../../../scripts/build.ts ./src/index.ts ./dist",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit && tsc --project tsconfig.test.json --noEmit",
+    "lint": "eslint src --ext .ts"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.5",
+    "typescript": "next"
+  }
+}

--- a/packages/core/config/src/file-provider.test.ts
+++ b/packages/core/config/src/file-provider.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { FileProvider, createFileProvider } from "./file-provider.ts";
+
+const TEST_DIR = join(import.meta.dir, ".test-config");
+
+describe("FileProvider", () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+  });
+
+  describe("getAll / setAll", () => {
+    it("should return undefined for non-existent namespace", async () => {
+      const provider = new FileProvider({ basePath: TEST_DIR });
+      const result = await provider.getAll("platform");
+      expect(result).toBeUndefined();
+    });
+
+    it("should write and read config", async () => {
+      const provider = new FileProvider({ basePath: TEST_DIR });
+      const config = { name: "test-platform", version: "1.0.0" };
+
+      await provider.setAll("platform", config);
+      const result = await provider.getAll("platform");
+
+      expect(result).toEqual(config);
+    });
+
+    it("should create directory if it doesn't exist", async () => {
+      const nestedDir = join(TEST_DIR, "nested", "path");
+      const provider = new FileProvider({ basePath: nestedDir });
+
+      await provider.setAll("platform", { name: "test" });
+
+      expect(existsSync(nestedDir)).toBe(true);
+      const result = await provider.getAll("platform");
+      expect(result).toEqual({ name: "test" });
+    });
+
+    it("should overwrite existing config", async () => {
+      const provider = new FileProvider({ basePath: TEST_DIR });
+
+      await provider.setAll("platform", { name: "old" });
+      await provider.setAll("platform", { name: "new", version: "2.0.0" });
+
+      const result = await provider.getAll("platform");
+      expect(result).toEqual({ name: "new", version: "2.0.0" });
+    });
+  });
+
+  describe("get / set", () => {
+    it("should get top-level value", async () => {
+      const provider = new FileProvider({ basePath: TEST_DIR });
+      await provider.setAll("platform", { name: "test", version: "1.0.0" });
+
+      const result = await provider.get("platform.name");
+      expect(result).toBe("test");
+    });
+
+    it("should get nested value", async () => {
+      const provider = new FileProvider({ basePath: TEST_DIR });
+      await provider.setAll("platform", {
+        registry: { url: "https://example.com" },
+      });
+
+      const result = await provider.get("platform.registry.url");
+      expect(result).toBe("https://example.com");
+    });
+
+    it("should return undefined for missing key", async () => {
+      const provider = new FileProvider({ basePath: TEST_DIR });
+      await provider.setAll("platform", { name: "test" });
+
+      const result = await provider.get("platform.missing");
+      expect(result).toBeUndefined();
+    });
+
+    it("should set nested value", async () => {
+      const provider = new FileProvider({ basePath: TEST_DIR });
+      await provider.setAll("platform", { name: "test" });
+
+      await provider.set("platform.version", "2.0.0");
+
+      const result = await provider.getAll("platform");
+      expect(result).toEqual({ name: "test", version: "2.0.0" });
+    });
+
+    it("should create nested structure", async () => {
+      const provider = new FileProvider({ basePath: TEST_DIR });
+
+      await provider.setAll("platform", {});
+      await provider.set("platform.registry.url", "https://example.com");
+
+      const result = await provider.get("platform.registry.url");
+      expect(result).toBe("https://example.com");
+    });
+
+    it("should throw when setting entire namespace via set", async () => {
+      const provider = new FileProvider({ basePath: TEST_DIR });
+
+      await expect(
+        provider.set("platform", { name: "test" })
+      ).rejects.toThrow("use setAll()");
+    });
+
+    it("should throw for invalid key", async () => {
+      const provider = new FileProvider({ basePath: TEST_DIR });
+
+      await expect(provider.set("", "value")).rejects.toThrow("Invalid key");
+    });
+  });
+
+  describe("isAvailable", () => {
+    it("should return true when base path exists", async () => {
+      const provider = new FileProvider({ basePath: TEST_DIR });
+      expect(await provider.isAvailable()).toBe(true);
+    });
+
+    it("should return false when base path doesn't exist", async () => {
+      const provider = new FileProvider({ basePath: join(TEST_DIR, "nonexistent") });
+      expect(await provider.isAvailable()).toBe(false);
+    });
+  });
+
+  describe("validateConfigValue", () => {
+    it("should reject non-JSON values", async () => {
+      const provider = new FileProvider({ basePath: TEST_DIR });
+
+      await expect(
+        provider.set("platform.func", (() => {}) as any)
+      ).rejects.toThrow("Invalid config value type");
+    });
+  });
+});
+
+describe("createFileProvider", () => {
+  it("should create provider from file:// URI", () => {
+    const provider = createFileProvider("file:///path/to/config");
+    expect(provider).toBeInstanceOf(FileProvider);
+  });
+
+  it("should throw for invalid URI", () => {
+    expect(() => createFileProvider("invalid://uri")).toThrow("Invalid file:// URI");
+  });
+
+  it("should throw for non-file scheme", () => {
+    expect(() => createFileProvider("s3://bucket/path")).toThrow("Invalid file:// URI");
+  });
+});

--- a/packages/core/config/src/file-provider.ts
+++ b/packages/core/config/src/file-provider.ts
@@ -1,0 +1,118 @@
+/**
+ * File-based config provider (file://)
+ * Reads and writes JSON config files from the local filesystem.
+ */
+
+import { existsSync } from "node:fs";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import type { ConfigProvider, ConfigValue, ConfigObject } from "./types.ts";
+import { getByPath, setByPath, validateConfigValue } from "./utils.ts";
+
+export interface FileProviderOptions {
+  basePath: string;
+}
+
+/**
+ * File-based configuration provider
+ * Stores config as JSON files in a directory structure
+ */
+export class FileProvider implements ConfigProvider {
+  private basePath: string;
+
+  constructor(options: FileProviderOptions) {
+    this.basePath = options.basePath;
+  }
+
+  async get(key: string): Promise<ConfigValue | undefined> {
+    const [namespace, ...rest] = key.split(".");
+    if (!namespace) {
+      return undefined;
+    }
+
+    const config = await this.getAll(namespace);
+    if (!config) {
+      return undefined;
+    }
+
+    if (rest.length === 0) {
+      return config;
+    }
+
+    return getByPath(config, rest.join("."));
+  }
+
+  async set(key: string, value: ConfigValue): Promise<void> {
+    const [namespace, ...rest] = key.split(".");
+    if (!namespace) {
+      throw new Error("Invalid key: must include namespace");
+    }
+
+    validateConfigValue(value);
+
+    const config = (await this.getAll(namespace)) || {};
+
+    if (rest.length === 0) {
+      throw new Error("Cannot set entire namespace with set(), use setAll()");
+    }
+
+    setByPath(config, rest.join("."), value);
+    await this.setAll(namespace, config);
+  }
+
+  async getAll(namespace: string): Promise<ConfigObject | undefined> {
+    const filePath = this.getFilePath(namespace);
+
+    if (!existsSync(filePath)) {
+      return undefined;
+    }
+
+    try {
+      const content = await readFile(filePath, "utf-8");
+      return JSON.parse(content) as ConfigObject;
+    } catch (error) {
+      throw new Error(`Failed to read config ${namespace}: ${error}`);
+    }
+  }
+
+  async setAll(namespace: string, value: ConfigObject): Promise<void> {
+    validateConfigValue(value);
+
+    const filePath = this.getFilePath(namespace);
+    const dir = dirname(filePath);
+
+    // Ensure directory exists
+    if (!existsSync(dir)) {
+      await mkdir(dir, { recursive: true });
+    }
+
+    try {
+      const content = JSON.stringify(value, null, 2);
+      await writeFile(filePath, content, "utf-8");
+    } catch (error) {
+      throw new Error(`Failed to write config ${namespace}: ${error}`);
+    }
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return existsSync(this.basePath);
+  }
+
+  private getFilePath(namespace: string): string {
+    return join(this.basePath, `${namespace}.json`);
+  }
+}
+
+/**
+ * Create a file-based config provider from a URI
+ * @param uri - file:// URI (e.g., "file:///path/to/config")
+ * @returns FileProvider instance
+ */
+export function createFileProvider(uri: string): FileProvider {
+  const match = uri.match(/^file:\/\/(.+)$/);
+  if (!match) {
+    throw new Error(`Invalid file:// URI: ${uri}`);
+  }
+
+  return new FileProvider({ basePath: match[1] });
+}

--- a/packages/core/config/src/index.ts
+++ b/packages/core/config/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @fe/config - Configuration provider abstraction for the FE platform
+ *
+ * Provides a unified interface for reading and writing platform configuration
+ * from various backends (file://, s3://, consul://, etc.)
+ *
+ * Phase 1 includes file:// provider only.
+ * Phase 13 will add remote providers.
+ */
+
+export * from "./types.ts";
+export * from "./utils.ts";
+export * from "./file-provider.ts";

--- a/packages/core/config/src/types.ts
+++ b/packages/core/config/src/types.ts
@@ -1,0 +1,146 @@
+/**
+ * Configuration types for the FE platform.
+ * All configuration is JSON-only as per ADR-018.
+ */
+
+/**
+ * Platform configuration (platform.json)
+ * Defines core platform settings and metadata.
+ */
+export interface PlatformConfig {
+  name: string;
+  version: string;
+  org: string;
+  registry?: {
+    url: string;
+    source?: string;
+    build?: string;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * Environment configuration (environments.json)
+ * Defines deployment environments and their settings.
+ */
+export interface Environment {
+  name: string;
+  url: string;
+  cdnUrl?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface EnvironmentsConfig {
+  environments: Environment[];
+}
+
+/**
+ * Rollout configuration (rollout.json)
+ * Tracks rollout state per MFE and environment.
+ */
+export interface RolloutState {
+  mfeName: string;
+  environment: string;
+  rolledOut: string;
+  rollingOut?: {
+    version: string;
+    percentage: number;
+  };
+}
+
+export interface RolloutConfig {
+  states: RolloutState[];
+}
+
+/**
+ * Governance configuration (governance.json)
+ * Defines scoring thresholds and permission rules.
+ */
+export interface GovernanceConfig {
+  scoring?: {
+    bundleSize?: {
+      maxKb: number;
+      weight: number;
+    };
+    coverage?: {
+      minPercent: number;
+      weight: number;
+    };
+    accessibility?: {
+      minScore: number;
+      weight: number;
+    };
+  };
+  permissions?: {
+    allowedScopes?: string[];
+    checksumVerification?: boolean;
+  };
+}
+
+/**
+ * Generic config value type
+ */
+export type ConfigValue = string | number | boolean | null | ConfigObject | ConfigArray;
+export interface ConfigObject {
+  [key: string]: ConfigValue;
+}
+export type ConfigArray = ConfigValue[];
+
+/**
+ * ConfigProvider interface - abstraction for config storage
+ * Implementations: file://, s3://, consul://, etcd://, postgres://, http://
+ */
+export interface ConfigProvider {
+  /**
+   * Retrieve a configuration value by key path
+   * @param key - Dot-separated path (e.g., "platform.name")
+   * @returns The configuration value or undefined if not found
+   */
+  get(key: string): Promise<ConfigValue | undefined>;
+
+  /**
+   * Set a configuration value by key path
+   * @param key - Dot-separated path
+   * @param value - The value to set
+   */
+  set(key: string, value: ConfigValue): Promise<void>;
+
+  /**
+   * Get the entire configuration object for a namespace
+   * @param namespace - The config namespace (e.g., "platform", "environments")
+   * @returns The configuration object
+   */
+  getAll(namespace: string): Promise<ConfigObject | undefined>;
+
+  /**
+   * Set the entire configuration object for a namespace
+   * @param namespace - The config namespace
+   * @param value - The configuration object
+   */
+  setAll(namespace: string, value: ConfigObject): Promise<void>;
+
+  /**
+   * Check if the provider is available and accessible
+   */
+  isAvailable(): Promise<boolean>;
+
+  /**
+   * Close any resources held by the provider
+   */
+  close?(): Promise<void>;
+}
+
+/**
+ * Config provider URI schemes
+ */
+export type ConfigProviderScheme = "file" | "s3" | "consul" | "etcd" | "postgres" | "http" | "https";
+
+/**
+ * Options for creating a config provider
+ */
+export interface ConfigProviderOptions {
+  uri: string;
+  basePath?: string;
+  timeout?: number;
+  [key: string]: unknown;
+}

--- a/packages/core/config/src/utils.test.ts
+++ b/packages/core/config/src/utils.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "bun:test";
+import { getByPath, setByPath, parseProviderUri, validateConfigValue } from "./utils.ts";
+
+describe("getByPath", () => {
+  it("should get top-level value", () => {
+    const obj = { name: "test" };
+    expect(getByPath(obj, "name")).toBe("test");
+  });
+
+  it("should get nested value", () => {
+    const obj = { registry: { url: "https://example.com" } };
+    expect(getByPath(obj, "registry.url")).toBe("https://example.com");
+  });
+
+  it("should return undefined for missing path", () => {
+    const obj = { name: "test" };
+    expect(getByPath(obj, "missing")).toBeUndefined();
+  });
+
+  it("should return undefined for nested missing path", () => {
+    const obj = { registry: { url: "https://example.com" } };
+    expect(getByPath(obj, "registry.missing")).toBeUndefined();
+  });
+
+  it("should return undefined when intermediate value is not an object", () => {
+    const obj = { name: "test" };
+    expect(getByPath(obj, "name.nested")).toBeUndefined();
+  });
+});
+
+describe("setByPath", () => {
+  it("should set top-level value", () => {
+    const obj = {};
+    setByPath(obj, "name", "test");
+    expect(obj).toEqual({ name: "test" });
+  });
+
+  it("should set nested value", () => {
+    const obj = {};
+    setByPath(obj, "registry.url", "https://example.com");
+    expect(obj).toEqual({ registry: { url: "https://example.com" } });
+  });
+
+  it("should update existing value", () => {
+    const obj = { name: "old" };
+    setByPath(obj, "name", "new");
+    expect(obj).toEqual({ name: "new" });
+  });
+
+  it("should throw for empty path", () => {
+    const obj = {};
+    expect(() => setByPath(obj, "", "value")).toThrow("Invalid path");
+  });
+
+  it("should throw when intermediate value is not an object", () => {
+    const obj = { name: "test" };
+    expect(() => setByPath(obj, "name.nested", "value")).toThrow("not an object");
+  });
+});
+
+describe("parseProviderUri", () => {
+  it("should parse file:// URI", () => {
+    const result = parseProviderUri("file:///path/to/config");
+    expect(result.scheme).toBe("file");
+    expect(result.path).toBe("/path/to/config");
+  });
+
+  it("should parse s3:// URI with host", () => {
+    const result = parseProviderUri("s3://bucket/path");
+    expect(result.scheme).toBe("s3");
+    expect(result.host).toBe("bucket");
+    expect(result.path).toBe("/path");
+  });
+
+  it("should parse http:// URI", () => {
+    const result = parseProviderUri("http://example.com/config");
+    expect(result.scheme).toBe("http");
+    expect(result.host).toBe("example.com");
+    expect(result.path).toBe("/config");
+  });
+
+  it("should throw for invalid URI", () => {
+    expect(() => parseProviderUri("invalid")).toThrow("Invalid provider URI");
+  });
+});
+
+describe("validateConfigValue", () => {
+  it("should allow null", () => {
+    expect(validateConfigValue(null)).toBe(true);
+  });
+
+  it("should allow string", () => {
+    expect(validateConfigValue("test")).toBe(true);
+  });
+
+  it("should allow number", () => {
+    expect(validateConfigValue(42)).toBe(true);
+  });
+
+  it("should allow boolean", () => {
+    expect(validateConfigValue(true)).toBe(true);
+  });
+
+  it("should allow array", () => {
+    expect(validateConfigValue([1, 2, 3])).toBe(true);
+  });
+
+  it("should allow object", () => {
+    expect(validateConfigValue({ key: "value" })).toBe(true);
+  });
+
+  it("should allow nested structures", () => {
+    expect(
+      validateConfigValue({
+        name: "test",
+        items: [1, 2, { nested: true }],
+        meta: { count: 5 },
+      })
+    ).toBe(true);
+  });
+
+  it("should reject function", () => {
+    expect(() => validateConfigValue(() => {})).toThrow("Invalid config value type");
+  });
+
+  it("should reject symbol", () => {
+    expect(() => validateConfigValue(Symbol("test"))).toThrow("Invalid config value type");
+  });
+});

--- a/packages/core/config/src/utils.ts
+++ b/packages/core/config/src/utils.ts
@@ -1,0 +1,125 @@
+/**
+ * Utility functions for config manipulation
+ */
+
+import type { ConfigValue, ConfigObject } from "./types.ts";
+
+/**
+ * Get a value from an object using dot notation path
+ * @param obj - The source object
+ * @param path - Dot-separated path (e.g., "registry.url")
+ * @returns The value at the path or undefined
+ */
+export function getByPath(obj: ConfigObject, path: string): ConfigValue | undefined {
+  const keys = path.split(".");
+  let current: ConfigValue = obj;
+
+  for (const key of keys) {
+    if (typeof current !== "object" || current === null || Array.isArray(current)) {
+      return undefined;
+    }
+    current = current[key];
+    if (current === undefined) {
+      return undefined;
+    }
+  }
+
+  return current;
+}
+
+/**
+ * Set a value in an object using dot notation path
+ * @param obj - The target object
+ * @param path - Dot-separated path
+ * @param value - The value to set
+ */
+export function setByPath(obj: ConfigObject, path: string, value: ConfigValue): void {
+  const keys = path.split(".");
+  const lastKey = keys.pop();
+  if (!lastKey) {
+    throw new Error("Invalid path: cannot be empty");
+  }
+
+  let current: ConfigValue = obj;
+  for (const key of keys) {
+    if (typeof current !== "object" || current === null || Array.isArray(current)) {
+      throw new Error(`Cannot set path ${path}: intermediate value is not an object`);
+    }
+
+    if (current[key] === undefined) {
+      current[key] = {};
+    }
+    current = current[key];
+  }
+
+  if (typeof current !== "object" || current === null || Array.isArray(current)) {
+    throw new Error(`Cannot set path ${path}: parent is not an object`);
+  }
+
+  current[lastKey] = value;
+}
+
+/**
+ * Parse a config provider URI
+ * @param uri - Provider URI (e.g., "file:///path/to/config", "s3://bucket/path")
+ * @returns Parsed components
+ */
+export function parseProviderUri(uri: string): {
+  scheme: string;
+  path: string;
+  host?: string;
+} {
+  // Match scheme://[host][path]
+  const match = uri.match(/^([a-z0-9]+):\/\/(.*)$/);
+  if (!match) {
+    throw new Error(`Invalid provider URI: ${uri}`);
+  }
+
+  const [, scheme, rest] = match;
+
+  // Split host and path
+  const slashIndex = rest.indexOf("/");
+  if (slashIndex === -1) {
+    // No path, only host (or empty)
+    return {
+      scheme,
+      host: rest || undefined,
+      path: "/",
+    };
+  }
+
+  const host = rest.substring(0, slashIndex);
+  const path = rest.substring(slashIndex);
+
+  return {
+    scheme,
+    host: host || undefined,
+    path: path || "/",
+  };
+}
+
+/**
+ * Validate that a value is valid JSON-serializable config
+ * @param value - The value to validate
+ * @returns true if valid, throws otherwise
+ */
+export function validateConfigValue(value: unknown): value is ConfigValue {
+  if (value === null || value === undefined) {
+    return true;
+  }
+
+  const type = typeof value;
+  if (type === "string" || type === "number" || type === "boolean") {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.every(validateConfigValue);
+  }
+
+  if (type === "object") {
+    return Object.values(value as Record<string, unknown>).every(validateConfigValue);
+  }
+
+  throw new Error(`Invalid config value type: ${type}`);
+}

--- a/packages/core/config/tsconfig.json
+++ b/packages/core/config/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.package.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/core/config/tsconfig.test.json
+++ b/packages/core/config/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.test.ts"]
+}

--- a/packages/core/import-map/README.md
+++ b/packages/core/import-map/README.md
@@ -1,0 +1,144 @@
+# @fe/import-map
+
+Import map generation for the FE platform.
+
+## Purpose
+
+Generates browser import maps from platform configuration. Import maps enable the browser to resolve `fe:` specifiers to actual CDN URLs at runtime.
+
+## Usage
+
+### Generating an Import Map
+
+```typescript
+import { generateImportMap } from "@fe/import-map";
+import type { ImportMapConfig } from "@fe/import-map";
+
+const config: ImportMapConfig = {
+  cdnUrl: "https://cdn.example.com",
+  platform: [
+    { specifier: "fe:state", version: "1.0.0" },
+    { specifier: "fe:routing", version: "1.0.0" },
+  ],
+  externals: [
+    { name: "react", version: "18.2.0" },
+  ],
+  mfes: [
+    {
+      name: "@myorg/dashboard",
+      version: "1.0.0",
+      dependencies: {
+        "fe:state": "1.0.0",
+        react: "18.2.0",
+      },
+    },
+  ],
+};
+
+const importMap = generateImportMap(config);
+```
+
+### Serializing to JSON
+
+```typescript
+import { serializeImportMap } from "@fe/import-map";
+
+const json = serializeImportMap(importMap);
+console.log(json);
+```
+
+### Generating HTML Script Tag
+
+```typescript
+import { generateImportMapScript } from "@fe/import-map";
+
+const scriptTag = generateImportMapScript(importMap);
+// <script type="importmap">
+// {
+//   "imports": { ... }
+// }
+// </script>
+```
+
+### Custom URL Builder
+
+```typescript
+const importMap = generateImportMap(config, {
+  urlBuilder: (entry) => {
+    // Custom logic for building URLs
+    return `https://custom-cdn.com/${entry.name}@${entry.version}`;
+  },
+});
+```
+
+## Import Map Structure
+
+The generated import map follows the [WICG Import Maps specification](https://github.com/WICG/import-maps):
+
+```json
+{
+  "imports": {
+    "fe:@myorg/dashboard": "https://cdn.example.com/mfes/@myorg/dashboard/1.0.0/index.js",
+    "fe:state": "https://cdn.example.com/platform/state/1.0.0/index.js",
+    "react": "https://cdn.example.com/vendor/react/18.2.0/index.js"
+  },
+  "scopes": {
+    "https://cdn.example.com/mfes/@myorg/dashboard/1.0.0/": {
+      "fe:state": "https://cdn.example.com/platform/state/1.0.0/index.js",
+      "react": "https://cdn.example.com/vendor/react/18.2.0/index.js"
+    }
+  }
+}
+```
+
+## How It Works
+
+1. **Top-level imports**: Maps `fe:` specifiers and external packages to URLs
+2. **Scoped dependencies**: Each MFE gets a scope with its specific dependency versions
+3. **URL construction**: Builds CDN URLs based on package name and version
+
+## URL Patterns
+
+By default, URLs are generated using these patterns:
+
+- **Platform packages**: `{cdnUrl}/platform/{name}/{version}/index.js`
+  - Example: `fe:state` → `https://cdn.example.com/platform/state/1.0.0/index.js`
+
+- **MFEs**: `{cdnUrl}/mfes/{name}/{version}/index.js`
+  - Example: `fe:@myorg/app` → `https://cdn.example.com/mfes/@myorg/app/1.0.0/index.js`
+
+- **Externals**: `{cdnUrl}/vendor/{name}/{version}/index.js`
+  - Example: `react` → `https://cdn.example.com/vendor/react/18.2.0/index.js`
+
+## Configuration Options
+
+### ImportMapConfig
+
+- `cdnUrl` - Base CDN URL
+- `environment` - Environment name (optional, for context)
+- `mfes` - Array of MFE entries
+- `platform` - Array of platform package entries
+- `externals` - Array of external library entries
+
+### ImportMapGeneratorOptions
+
+- `includeIntegrity` - Include subresource integrity hashes (Phase 1: not implemented)
+- `trailingSlash` - Use trailing slashes for scope URLs (default: true)
+- `urlBuilder` - Custom function for building URLs
+
+## Browser Support
+
+Import maps are supported in:
+- Chrome 89+
+- Edge 89+
+- Safari 16.4+
+- Firefox 108+
+
+For older browsers, use the [es-module-shims polyfill](https://github.com/guybedford/es-module-shims).
+
+## Design Principles
+
+1. **Follows WICG spec**: Standard import maps
+2. **Scoped dependencies**: Each MFE can have different versions
+3. **One Version Policy**: Top-level imports define the rolled-out version
+4. **Extensible**: Custom URL builders for different CDN strategies

--- a/packages/core/import-map/package.json
+++ b/packages/core/import-map/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@fe/import-map",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "bun ../../../scripts/build.ts ./src/index.ts ./dist",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit && tsc --project tsconfig.test.json --noEmit",
+    "lint": "eslint src --ext .ts"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.5",
+    "typescript": "next"
+  }
+}

--- a/packages/core/import-map/src/generator.test.ts
+++ b/packages/core/import-map/src/generator.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from "bun:test";
+import {
+  generateImportMap,
+  serializeImportMap,
+  generateImportMapScript,
+} from "./generator.ts";
+import type { ImportMapConfig } from "./types.ts";
+
+describe("generateImportMap", () => {
+  const baseCdnUrl = "https://cdn.example.com";
+
+  it("should generate import map with MFEs only", () => {
+    const config: ImportMapConfig = {
+      cdnUrl: baseCdnUrl,
+      mfes: [
+        { name: "@myorg/app1", version: "1.0.0" },
+        { name: "@myorg/app2", version: "2.1.0" },
+      ],
+    };
+
+    const importMap = generateImportMap(config);
+
+    expect(importMap.imports).toEqual({
+      "fe:@myorg/app1": `${baseCdnUrl}/mfes/@myorg/app1/1.0.0/index.js`,
+      "fe:@myorg/app2": `${baseCdnUrl}/mfes/@myorg/app2/2.1.0/index.js`,
+    });
+  });
+
+  it("should generate import map with platform packages", () => {
+    const config: ImportMapConfig = {
+      cdnUrl: baseCdnUrl,
+      mfes: [],
+      platform: [
+        { specifier: "fe:state", version: "1.0.0" },
+        { specifier: "fe:routing", version: "1.2.0" },
+      ],
+    };
+
+    const importMap = generateImportMap(config);
+
+    expect(importMap.imports).toEqual({
+      "fe:state": `${baseCdnUrl}/platform/state/1.0.0/index.js`,
+      "fe:routing": `${baseCdnUrl}/platform/routing/1.2.0/index.js`,
+    });
+  });
+
+  it("should generate import map with externals", () => {
+    const config: ImportMapConfig = {
+      cdnUrl: baseCdnUrl,
+      mfes: [],
+      externals: [
+        { name: "react", version: "18.2.0" },
+        { name: "react-dom", version: "18.2.0" },
+      ],
+    };
+
+    const importMap = generateImportMap(config);
+
+    expect(importMap.imports).toEqual({
+      react: `${baseCdnUrl}/vendor/react/18.2.0/index.js`,
+      "react-dom": `${baseCdnUrl}/vendor/react-dom/18.2.0/index.js`,
+    });
+  });
+
+  it("should generate scoped dependencies for MFE", () => {
+    const config: ImportMapConfig = {
+      cdnUrl: baseCdnUrl,
+      mfes: [
+        {
+          name: "@myorg/app1",
+          version: "1.0.0",
+          dependencies: {
+            "fe:state": "1.0.0",
+            react: "18.2.0",
+          },
+        },
+      ],
+    };
+
+    const importMap = generateImportMap(config);
+
+    expect(importMap.imports?.["fe:@myorg/app1"]).toBe(
+      `${baseCdnUrl}/mfes/@myorg/app1/1.0.0/index.js`
+    );
+
+    expect(importMap.scopes).toBeDefined();
+    const scopeUrl = `${baseCdnUrl}/mfes/@myorg/app1/1.0.0/`;
+    expect(importMap.scopes?.[scopeUrl]).toEqual({
+      "fe:state": `${baseCdnUrl}/platform/state/1.0.0/index.js`,
+      react: `${baseCdnUrl}/vendor/react/18.2.0/index.js`,
+    });
+  });
+
+  it("should handle custom URLs", () => {
+    const config: ImportMapConfig = {
+      cdnUrl: baseCdnUrl,
+      mfes: [
+        {
+          name: "@myorg/app1",
+          version: "1.0.0",
+          url: "https://custom.cdn.com/app1.js",
+        },
+      ],
+    };
+
+    const importMap = generateImportMap(config);
+
+    expect(importMap.imports?.["fe:@myorg/app1"]).toBe("https://custom.cdn.com/app1.js");
+  });
+
+  it("should handle relative custom URLs", () => {
+    const config: ImportMapConfig = {
+      cdnUrl: baseCdnUrl,
+      mfes: [
+        {
+          name: "@myorg/app1",
+          version: "1.0.0",
+          url: "/custom/path/app1.js",
+        },
+      ],
+    };
+
+    const importMap = generateImportMap(config);
+
+    expect(importMap.imports?.["fe:@myorg/app1"]).toBe(`${baseCdnUrl}/custom/path/app1.js`);
+  });
+
+  it("should use custom URL builder", () => {
+    const config: ImportMapConfig = {
+      cdnUrl: baseCdnUrl,
+      mfes: [{ name: "@myorg/app1", version: "1.0.0" }],
+    };
+
+    const importMap = generateImportMap(config, {
+      urlBuilder: (entry) => `https://custom.com/${entry.name}/${entry.version}.js`,
+    });
+
+    expect(importMap.imports?.["fe:@myorg/app1"]).toBe(
+      "https://custom.com/@myorg/app1/1.0.0.js"
+    );
+  });
+
+  it("should omit trailing slash when option is false", () => {
+    const config: ImportMapConfig = {
+      cdnUrl: baseCdnUrl,
+      mfes: [
+        {
+          name: "@myorg/app1",
+          version: "1.0.0",
+          dependencies: { react: "18.2.0" },
+        },
+      ],
+    };
+
+    const importMap = generateImportMap(config, { trailingSlash: false });
+
+    const scopeUrl = `${baseCdnUrl}/mfes/@myorg/app1/1.0.0`;
+    expect(importMap.scopes?.[scopeUrl]).toBeDefined();
+  });
+
+  it("should generate complete import map", () => {
+    const config: ImportMapConfig = {
+      cdnUrl: baseCdnUrl,
+      environment: "production",
+      platform: [
+        { specifier: "fe:state", version: "1.0.0" },
+        { specifier: "fe:routing", version: "1.0.0" },
+      ],
+      externals: [{ name: "react", version: "18.2.0" }],
+      mfes: [
+        {
+          name: "@myorg/app1",
+          version: "1.0.0",
+          dependencies: {
+            "fe:state": "1.0.0",
+            react: "18.2.0",
+          },
+        },
+        {
+          name: "@myorg/app2",
+          version: "2.0.0",
+          dependencies: {
+            "fe:@myorg/app1": "1.0.0",
+          },
+        },
+      ],
+    };
+
+    const importMap = generateImportMap(config);
+
+    // Check all imports are present
+    expect(importMap.imports?.["fe:state"]).toBeDefined();
+    expect(importMap.imports?.["fe:routing"]).toBeDefined();
+    expect(importMap.imports?.react).toBeDefined();
+    expect(importMap.imports?.["fe:@myorg/app1"]).toBeDefined();
+    expect(importMap.imports?.["fe:@myorg/app2"]).toBeDefined();
+
+    // Check scopes
+    expect(importMap.scopes).toBeDefined();
+    expect(Object.keys(importMap.scopes!).length).toBe(2);
+  });
+});
+
+describe("serializeImportMap", () => {
+  it("should serialize with pretty formatting", () => {
+    const importMap = {
+      imports: {
+        "fe:state": "https://cdn.example.com/platform/state/1.0.0/index.js",
+      },
+    };
+
+    const json = serializeImportMap(importMap);
+
+    expect(json).toContain("\n");
+    expect(json).toContain("  ");
+    expect(JSON.parse(json)).toEqual(importMap);
+  });
+
+  it("should serialize without formatting", () => {
+    const importMap = {
+      imports: {
+        "fe:state": "https://cdn.example.com/platform/state/1.0.0/index.js",
+      },
+    };
+
+    const json = serializeImportMap(importMap, false);
+
+    expect(json).not.toContain("\n");
+    expect(JSON.parse(json)).toEqual(importMap);
+  });
+});
+
+describe("generateImportMapScript", () => {
+  it("should generate script tag with import map", () => {
+    const importMap = {
+      imports: {
+        "fe:state": "https://cdn.example.com/platform/state/1.0.0/index.js",
+      },
+    };
+
+    const script = generateImportMapScript(importMap);
+
+    expect(script).toContain('<script type="importmap">');
+    expect(script).toContain("</script>");
+    expect(script).toContain('"imports"');
+    expect(script).toContain('"fe:state"');
+  });
+
+  it("should produce valid HTML script tag", () => {
+    const importMap = {
+      imports: { test: "https://example.com/test.js" },
+    };
+
+    const script = generateImportMapScript(importMap);
+
+    // Should start and end correctly
+    expect(script.startsWith('<script type="importmap">')).toBe(true);
+    expect(script.endsWith("</script>")).toBe(true);
+
+    // Should contain valid JSON
+    const jsonMatch = script.match(/<script type="importmap">\n(.*)\n<\/script>/s);
+    expect(jsonMatch).toBeTruthy();
+    if (jsonMatch) {
+      expect(() => JSON.parse(jsonMatch[1])).not.toThrow();
+    }
+  });
+});

--- a/packages/core/import-map/src/generator.ts
+++ b/packages/core/import-map/src/generator.ts
@@ -1,0 +1,183 @@
+/**
+ * Import map generator - generates import maps from configuration
+ */
+
+import type {
+  ImportMap,
+  ImportMapConfig,
+  ImportMapGeneratorOptions,
+  MfeEntry,
+  PlatformEntry,
+  ExternalEntry,
+} from "./types.ts";
+
+/**
+ * Generate an import map from configuration
+ * @param config - Import map configuration
+ * @param options - Generator options
+ * @returns Generated import map
+ */
+export function generateImportMap(
+  config: ImportMapConfig,
+  options: ImportMapGeneratorOptions = {}
+): ImportMap {
+  const { trailingSlash = true, urlBuilder } = options;
+  const imports: Record<string, string> = {};
+  const scopes: Record<string, Record<string, string>> = {};
+
+  // Add platform packages
+  if (config.platform) {
+    for (const entry of config.platform) {
+      const url = urlBuilder
+        ? urlBuilder(entry)
+        : buildPlatformUrl(config.cdnUrl, entry);
+
+      imports[entry.specifier] = url;
+    }
+  }
+
+  // Add externals (e.g., React, Vue)
+  if (config.externals) {
+    for (const entry of config.externals) {
+      const url = urlBuilder
+        ? urlBuilder(entry)
+        : buildExternalUrl(config.cdnUrl, entry);
+
+      imports[entry.name] = url;
+    }
+  }
+
+  // Add MFEs
+  for (const mfe of config.mfes) {
+    const mfeUrl = urlBuilder
+      ? urlBuilder(mfe)
+      : buildMfeUrl(config.cdnUrl, mfe);
+
+    // Add MFE to imports
+    const specifier = `fe:${mfe.name}`;
+    imports[specifier] = mfeUrl;
+
+    // Add scoped dependencies if any
+    if (mfe.dependencies && Object.keys(mfe.dependencies).length > 0) {
+      const scopeBase = getScopeBase(mfeUrl);
+      const scopeUrl = trailingSlash && !scopeBase.endsWith("/")
+        ? `${scopeBase}/`
+        : scopeBase;
+
+      scopes[scopeUrl] = scopes[scopeUrl] || {};
+
+      for (const [depName, depVersion] of Object.entries(mfe.dependencies)) {
+        if (depName.startsWith("fe:")) {
+          // Platform package or other MFE
+          const depUrl = buildMfeOrPlatformUrl(config.cdnUrl, depName, depVersion);
+          scopes[scopeUrl][depName] = depUrl;
+        } else {
+          // External library
+          const depUrl = buildExternalUrl(config.cdnUrl, {
+            name: depName,
+            version: depVersion,
+          });
+          scopes[scopeUrl][depName] = depUrl;
+        }
+      }
+    }
+  }
+
+  const importMap: ImportMap = {
+    imports,
+  };
+
+  if (Object.keys(scopes).length > 0) {
+    importMap.scopes = scopes;
+  }
+
+  return importMap;
+}
+
+/**
+ * Build URL for a platform package
+ */
+function buildPlatformUrl(cdnUrl: string, entry: PlatformEntry): string {
+  if (entry.url) {
+    return entry.url.startsWith("http") ? entry.url : `${cdnUrl}${entry.url}`;
+  }
+
+  // Extract package name from specifier (fe:state -> state)
+  const packageName = entry.specifier.replace(/^fe:/, "");
+  return `${cdnUrl}/platform/${packageName}/${entry.version}/index.js`;
+}
+
+/**
+ * Build URL for an external library
+ */
+function buildExternalUrl(
+  cdnUrl: string,
+  entry: ExternalEntry
+): string {
+  if (entry.url) {
+    return entry.url.startsWith("http") ? entry.url : `${cdnUrl}${entry.url}`;
+  }
+
+  return `${cdnUrl}/vendor/${entry.name}/${entry.version}/index.js`;
+}
+
+/**
+ * Build URL for an MFE
+ */
+function buildMfeUrl(cdnUrl: string, entry: MfeEntry): string {
+  if (entry.url) {
+    return entry.url.startsWith("http") ? entry.url : `${cdnUrl}${entry.url}`;
+  }
+
+  return `${cdnUrl}/mfes/${entry.name}/${entry.version}/index.js`;
+}
+
+/**
+ * Build URL for MFE or platform package by specifier
+ */
+function buildMfeOrPlatformUrl(
+  cdnUrl: string,
+  specifier: string,
+  version: string
+): string {
+  if (specifier.startsWith("fe:@")) {
+    // MFE reference
+    const packageName = specifier.replace(/^fe:/, "");
+    return `${cdnUrl}/mfes/${packageName}/${version}/index.js`;
+  } else if (specifier.startsWith("fe:")) {
+    // Platform package
+    const packageName = specifier.replace(/^fe:/, "");
+    return `${cdnUrl}/platform/${packageName}/${version}/index.js`;
+  }
+
+  throw new Error(`Invalid fe: specifier: ${specifier}`);
+}
+
+/**
+ * Get the scope base URL from an MFE URL
+ * Extracts the directory containing the MFE
+ */
+function getScopeBase(url: string): string {
+  const lastSlash = url.lastIndexOf("/");
+  return url.substring(0, lastSlash);
+}
+
+/**
+ * Serialize an import map to JSON string
+ * @param importMap - Import map to serialize
+ * @param pretty - Whether to pretty-print
+ * @returns JSON string
+ */
+export function serializeImportMap(importMap: ImportMap, pretty = true): string {
+  return JSON.stringify(importMap, null, pretty ? 2 : 0);
+}
+
+/**
+ * Generate import map HTML script tag
+ * @param importMap - Import map to embed
+ * @returns HTML script tag string
+ */
+export function generateImportMapScript(importMap: ImportMap): string {
+  const json = serializeImportMap(importMap);
+  return `<script type="importmap">\n${json}\n</script>`;
+}

--- a/packages/core/import-map/src/index.ts
+++ b/packages/core/import-map/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @fe/import-map - Import map generation for the FE platform
+ *
+ * Generates browser import maps from platform configuration.
+ * Maps fe: specifiers to CDN URLs for runtime module resolution.
+ */
+
+export * from "./types.ts";
+export * from "./generator.ts";

--- a/packages/core/import-map/src/types.ts
+++ b/packages/core/import-map/src/types.ts
@@ -1,0 +1,119 @@
+/**
+ * Import map types for the FE platform
+ * Based on WICG Import Maps specification
+ */
+
+/**
+ * Import map structure
+ * @see https://github.com/WICG/import-maps
+ */
+export interface ImportMap {
+  /** Top-level import mappings */
+  imports?: ImportMapEntries;
+
+  /** Scoped import mappings */
+  scopes?: ImportMapScopes;
+
+  /** Integrity metadata (optional) */
+  integrity?: IntegrityMetadata;
+}
+
+/**
+ * Import mapping entries (specifier -> URL)
+ */
+export interface ImportMapEntries {
+  [specifier: string]: string;
+}
+
+/**
+ * Scoped mappings (scope URL -> mappings)
+ */
+export interface ImportMapScopes {
+  [scopeUrl: string]: ImportMapEntries;
+}
+
+/**
+ * Integrity metadata for subresource integrity
+ */
+export interface IntegrityMetadata {
+  [url: string]: string;
+}
+
+/**
+ * Configuration for generating an import map
+ */
+export interface ImportMapConfig {
+  /** Base CDN URL */
+  cdnUrl: string;
+
+  /** Environment name */
+  environment?: string;
+
+  /** MFE entries to include */
+  mfes: MfeEntry[];
+
+  /** Platform package entries */
+  platform?: PlatformEntry[];
+
+  /** External library entries */
+  externals?: ExternalEntry[];
+}
+
+/**
+ * MFE entry for import map generation
+ */
+export interface MfeEntry {
+  /** Package name (e.g., "@myorg/my-mfe") */
+  name: string;
+
+  /** Version */
+  version: string;
+
+  /** Entry point URL (relative to CDN or absolute) */
+  url?: string;
+
+  /** Dependencies to include in scope */
+  dependencies?: Record<string, string>;
+}
+
+/**
+ * Platform package entry
+ */
+export interface PlatformEntry {
+  /** Platform package specifier (e.g., "fe:state") */
+  specifier: string;
+
+  /** Version */
+  version: string;
+
+  /** URL (relative to CDN or absolute) */
+  url?: string;
+}
+
+/**
+ * External library entry
+ */
+export interface ExternalEntry {
+  /** Package name (e.g., "react") */
+  name: string;
+
+  /** Version */
+  version: string;
+
+  /** URL (relative to CDN or absolute) */
+  url?: string;
+}
+
+/**
+ * Options for import map generation
+ */
+export interface ImportMapGeneratorOptions {
+  /** Whether to include integrity hashes */
+  includeIntegrity?: boolean;
+
+  /** Whether to use trailing slashes for directory mappings */
+  trailingSlash?: boolean;
+
+  /** Custom URL builder function */
+  urlBuilder?: (entry: MfeEntry | PlatformEntry | ExternalEntry) => string;
+}

--- a/packages/core/import-map/tsconfig.json
+++ b/packages/core/import-map/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.package.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/core/import-map/tsconfig.test.json
+++ b/packages/core/import-map/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.test.ts"]
+}

--- a/packages/core/manifest/README.md
+++ b/packages/core/manifest/README.md
@@ -1,0 +1,162 @@
+# @fe/manifest
+
+MFE manifest parsing and validation for the FE platform.
+
+## Purpose
+
+Provides types, parser, and validator for `fe.json` manifests that describe MFE metadata, dependencies, permissions, routes, and capabilities.
+
+## Usage
+
+### Parsing a Manifest
+
+```typescript
+import { parseManifest, parseManifestFile } from "@fe/manifest";
+
+// From string
+const manifest = parseManifest(jsonString);
+
+// From file
+const manifest = await parseManifestFile("./fe.json");
+```
+
+### Validating a Manifest
+
+```typescript
+import { validateManifest, assertValidManifest } from "@fe/manifest";
+
+// Get validation result
+const result = validateManifest(manifest);
+if (!result.valid) {
+  console.error("Validation errors:", result.errors);
+}
+
+// Assert valid (throws on error)
+assertValidManifest(manifest);
+```
+
+### Writing a Manifest
+
+```typescript
+import { writeManifestFile, stringifyManifest } from "@fe/manifest";
+import type { MfeManifest } from "@fe/manifest";
+
+const manifest: MfeManifest = {
+  name: "@myorg/my-mfe",
+  version: "1.0.0",
+  main: "./src/index.ts",
+  description: "My micro-frontend",
+};
+
+// Write to file
+await writeManifestFile("./fe.json", manifest);
+
+// Get JSON string
+const json = stringifyManifest(manifest);
+```
+
+## Manifest Structure
+
+### Minimal Example
+
+```json
+{
+  "name": "@myorg/my-mfe",
+  "version": "1.0.0",
+  "main": "./src/index.ts"
+}
+```
+
+### Complete Example
+
+```json
+{
+  "name": "@myorg/dashboard",
+  "version": "2.1.0",
+  "description": "User dashboard MFE",
+  "main": "./src/index.tsx",
+  "framework": "react",
+  "dependencies": {
+    "fe:state": "^1.0.0",
+    "fe:routing": "^1.0.0",
+    "fe:net": "^1.0.0",
+    "@myorg/shared-ui": "^3.0.0"
+  },
+  "permissions": {
+    "state": {
+      "owns": ["user", "dashboard"],
+      "reads": ["app", "auth"]
+    },
+    "network": {
+      "domains": ["api.example.com"],
+      "paths": ["/api/users/*", "/api/dashboard/*"]
+    },
+    "storage": {
+      "localStorage": true,
+      "cookies": ["user_prefs"]
+    }
+  },
+  "routes": [
+    {
+      "path": "/dashboard",
+      "component": "./components/Dashboard.tsx",
+      "meta": {
+        "title": "Dashboard",
+        "requiresAuth": true
+      }
+    },
+    {
+      "path": "/profile",
+      "component": "./components/Profile.tsx",
+      "meta": {
+        "title": "Profile",
+        "requiresAuth": true
+      }
+    }
+  ],
+  "capabilities": [
+    {
+      "id": "view-dashboard",
+      "name": "View Dashboard",
+      "description": "Display user dashboard with widgets",
+      "intents": ["view", "dashboard", "analytics"],
+      "examples": ["show my dashboard", "open analytics"]
+    }
+  ],
+  "ai": {
+    "keywords": ["dashboard", "analytics", "user-data"],
+    "summary": "Provides user dashboard with analytics and profile management",
+    "useCases": [
+      "View user statistics",
+      "Manage user profile",
+      "Access analytics"
+    ]
+  }
+}
+```
+
+## Required Fields
+
+- `name` - Scoped package name (e.g., `@myorg/my-mfe`)
+- `version` - Semantic version (e.g., `1.0.0`)
+- `main` - Entry point path (must be `.ts` or `.tsx`)
+
+## Optional Fields
+
+- `description` - Human-readable description
+- `framework` - Framework used (react, vue, svelte, etc.)
+- `dependencies` - Platform packages and other MFEs this depends on
+- `permissions` - Required permissions (state, network, storage, APIs)
+- `routes` - Routes exposed by this MFE
+- `capabilities` - Capabilities this MFE provides
+- `ai` - AI context for catalog discovery
+- `metadata` - Custom metadata
+
+## Validation Rules
+
+1. Package name must be scoped (`@org/name`)
+2. Version must be valid semver (`1.0.0`, `1.0.0-alpha.1`, `1.0.0+build.123`)
+3. Main entry must end with `.ts` or `.tsx`
+4. All dependency values must be strings
+5. Routes must have `path` and `component`
+6. Capabilities must have `id`, `name`, and `description`

--- a/packages/core/manifest/package.json
+++ b/packages/core/manifest/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@fe/manifest",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "bun ../../../scripts/build.ts ./src/index.ts ./dist",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit && tsc --project tsconfig.test.json --noEmit",
+    "lint": "eslint src --ext .ts"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.5",
+    "typescript": "next"
+  }
+}

--- a/packages/core/manifest/src/index.ts
+++ b/packages/core/manifest/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @fe/manifest - MFE manifest parsing and validation
+ *
+ * Provides types, parser, and validator for fe.json manifests.
+ */
+
+export * from "./types.ts";
+export * from "./parser.ts";
+export * from "./validator.ts";

--- a/packages/core/manifest/src/parser.test.ts
+++ b/packages/core/manifest/src/parser.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import {
+  parseManifest,
+  parseManifestFile,
+  stringifyManifest,
+  writeManifestFile,
+} from "./parser.ts";
+import type { MfeManifest } from "./types.ts";
+
+const TEST_DIR = join(import.meta.dir, ".test-manifests");
+
+describe("parseManifest", () => {
+  it("should parse valid JSON", () => {
+    const json = JSON.stringify({
+      name: "@myorg/my-mfe",
+      version: "1.0.0",
+      main: "./src/index.ts",
+    });
+
+    const manifest = parseManifest(json);
+    expect(manifest.name).toBe("@myorg/my-mfe");
+    expect(manifest.version).toBe("1.0.0");
+    expect(manifest.main).toBe("./src/index.ts");
+  });
+
+  it("should throw for invalid JSON", () => {
+    expect(() => parseManifest("not json")).toThrow("Failed to parse manifest");
+  });
+
+  it("should parse complex manifest", () => {
+    const json = JSON.stringify({
+      name: "@myorg/my-mfe",
+      version: "1.0.0",
+      main: "./src/index.ts",
+      dependencies: {
+        "fe:state": "^1.0.0",
+      },
+      routes: [
+        {
+          path: "/test",
+          component: "./Test.tsx",
+        },
+      ],
+    });
+
+    const manifest = parseManifest(json);
+    expect(manifest.dependencies).toBeDefined();
+    expect(manifest.dependencies?.["fe:state"]).toBe("^1.0.0");
+    expect(manifest.routes).toHaveLength(1);
+  });
+});
+
+describe("stringifyManifest", () => {
+  it("should stringify manifest with pretty formatting", () => {
+    const manifest: MfeManifest = {
+      name: "@myorg/my-mfe",
+      version: "1.0.0",
+      main: "./src/index.ts",
+    };
+
+    const json = stringifyManifest(manifest);
+    expect(json).toContain("\n");
+    expect(json).toContain("  ");
+    expect(JSON.parse(json)).toEqual(manifest);
+  });
+
+  it("should stringify manifest without formatting", () => {
+    const manifest: MfeManifest = {
+      name: "@myorg/my-mfe",
+      version: "1.0.0",
+      main: "./src/index.ts",
+    };
+
+    const json = stringifyManifest(manifest, false);
+    expect(json).not.toContain("\n");
+    expect(JSON.parse(json)).toEqual(manifest);
+  });
+});
+
+describe("parseManifestFile and writeManifestFile", () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+  });
+
+  it("should write and read manifest file", async () => {
+    const manifest: MfeManifest = {
+      name: "@myorg/my-mfe",
+      version: "1.0.0",
+      main: "./src/index.ts",
+      description: "Test MFE",
+    };
+
+    const filePath = join(TEST_DIR, "fe.json");
+    await writeManifestFile(filePath, manifest);
+
+    expect(existsSync(filePath)).toBe(true);
+
+    const read = await parseManifestFile(filePath);
+    expect(read).toEqual(manifest);
+  });
+
+  it("should throw for non-existent file", async () => {
+    const filePath = join(TEST_DIR, "nonexistent.json");
+
+    await expect(parseManifestFile(filePath)).rejects.toThrow("Failed to read manifest file");
+  });
+
+  it("should write pretty-formatted JSON", async () => {
+    const manifest: MfeManifest = {
+      name: "@myorg/my-mfe",
+      version: "1.0.0",
+      main: "./src/index.ts",
+    };
+
+    const filePath = join(TEST_DIR, "fe.json");
+    await writeManifestFile(filePath, manifest);
+
+    const file = Bun.file(filePath);
+    const content = await file.text();
+
+    expect(content).toContain("\n");
+    expect(content).toContain("  ");
+  });
+});

--- a/packages/core/manifest/src/parser.ts
+++ b/packages/core/manifest/src/parser.ts
@@ -1,0 +1,55 @@
+/**
+ * Manifest parser - reads and parses fe.json files
+ */
+
+import type { MfeManifest } from "./types.ts";
+
+/**
+ * Parse a manifest from JSON string
+ * @param content - JSON string content
+ * @returns Parsed manifest
+ * @throws Error if JSON is invalid
+ */
+export function parseManifest(content: string): MfeManifest {
+  try {
+    const manifest = JSON.parse(content);
+    return manifest as MfeManifest;
+  } catch (error) {
+    throw new Error(`Failed to parse manifest: ${error}`);
+  }
+}
+
+/**
+ * Parse a manifest from a file
+ * @param path - Path to fe.json
+ * @returns Parsed manifest
+ */
+export async function parseManifestFile(path: string): Promise<MfeManifest> {
+  try {
+    const file = Bun.file(path);
+    const content = await file.text();
+    return parseManifest(content);
+  } catch (error) {
+    throw new Error(`Failed to read manifest file ${path}: ${error}`);
+  }
+}
+
+/**
+ * Stringify a manifest to JSON
+ * @param manifest - Manifest object
+ * @param pretty - Whether to format with indentation
+ * @returns JSON string
+ */
+export function stringifyManifest(manifest: MfeManifest, pretty = true): string {
+  return JSON.stringify(manifest, null, pretty ? 2 : 0);
+}
+
+/**
+ * Write a manifest to a file
+ * @param path - Path to fe.json
+ * @param manifest - Manifest object
+ */
+export async function writeManifestFile(path: string, manifest: MfeManifest): Promise<void> {
+  const content = stringifyManifest(manifest);
+  await Bun.write(path, content);
+}

--- a/packages/core/manifest/src/types.ts
+++ b/packages/core/manifest/src/types.ts
@@ -1,0 +1,184 @@
+/**
+ * MFE Manifest types for the FE platform
+ * Defines the structure of fe.json manifests
+ */
+
+/**
+ * Main MFE manifest structure (fe.json)
+ */
+export interface MfeManifest {
+  /** MFE package name (e.g., "@myorg/my-mfe") */
+  name: string;
+
+  /** Semantic version */
+  version: string;
+
+  /** Human-readable description */
+  description?: string;
+
+  /** Main entry point (relative path from package root) */
+  main: string;
+
+  /** Framework used (react, vue, svelte, etc.) */
+  framework?: string;
+
+  /** Platform packages this MFE depends on */
+  dependencies?: MfeDependencies;
+
+  /** Permissions required by this MFE */
+  permissions?: MfePermissions;
+
+  /** Routes exposed by this MFE */
+  routes?: MfeRoute[];
+
+  /** Capabilities this MFE provides */
+  capabilities?: MfeCapability[];
+
+  /** AI context for catalog discovery */
+  ai?: MfeAiContext;
+
+  /** Custom metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Platform package dependencies
+ * Maps package name to version constraint
+ */
+export interface MfeDependencies {
+  /** fe:state */
+  "fe:state"?: string;
+
+  /** fe:routing */
+  "fe:routing"?: string;
+
+  /** fe:net or fe:net/{org} */
+  "fe:net"?: string;
+  [key: `fe:net/${string}`]: string;
+
+  /** fe:auth */
+  "fe:auth"?: string;
+
+  /** fe:i18n */
+  "fe:i18n"?: string;
+
+  /** fe:telemetry */
+  "fe:telemetry"?: string;
+
+  /** fe:visuals */
+  "fe:visuals"?: string;
+
+  /** fe:experimentation */
+  "fe:experimentation"?: string;
+
+  /** fe:test (dev only) */
+  "fe:test"?: string;
+
+  /** fe:plays/{org} */
+  [key: `fe:plays/${string}`]: string;
+
+  /** fe:scenes/{org} */
+  [key: `fe:scenes/${string}`]: string;
+
+  /** Other MFEs */
+  [key: string]: string;
+}
+
+/**
+ * Permission declarations
+ */
+export interface MfePermissions {
+  /** State slices this MFE owns */
+  state?: {
+    owns?: string[];
+    reads?: string[];
+  };
+
+  /** API endpoints this MFE can call */
+  network?: {
+    domains?: string[];
+    paths?: string[];
+  };
+
+  /** Storage access */
+  storage?: {
+    localStorage?: boolean;
+    sessionStorage?: boolean;
+    cookies?: string[];
+  };
+
+  /** Browser APIs */
+  apis?: string[];
+}
+
+/**
+ * Route definition
+ */
+export interface MfeRoute {
+  /** Route path pattern */
+  path: string;
+
+  /** Component to render */
+  component: string;
+
+  /** Route metadata */
+  meta?: {
+    title?: string;
+    requiresAuth?: boolean;
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * Capability declaration
+ */
+export interface MfeCapability {
+  /** Capability ID */
+  id: string;
+
+  /** Human-readable name */
+  name: string;
+
+  /** Description */
+  description: string;
+
+  /** Intent categories */
+  intents?: string[];
+
+  /** Example invocations */
+  examples?: string[];
+}
+
+/**
+ * AI context for catalog
+ */
+export interface MfeAiContext {
+  /** Keywords for search */
+  keywords?: string[];
+
+  /** What this MFE does */
+  summary?: string;
+
+  /** Use cases */
+  useCases?: string[];
+
+  /** Related MFEs */
+  related?: string[];
+}
+
+/**
+ * Validation error
+ */
+export interface ManifestValidationError {
+  field: string;
+  message: string;
+  value?: unknown;
+}
+
+/**
+ * Validation result
+ */
+export interface ManifestValidationResult {
+  valid: boolean;
+  errors: ManifestValidationError[];
+}

--- a/packages/core/manifest/src/validator.test.ts
+++ b/packages/core/manifest/src/validator.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "bun:test";
+import { validateManifest, assertValidManifest } from "./validator.ts";
+import type { MfeManifest } from "./types.ts";
+
+describe("validateManifest", () => {
+  const validManifest: MfeManifest = {
+    name: "@myorg/my-mfe",
+    version: "1.0.0",
+    main: "./src/index.ts",
+  };
+
+  it("should validate a minimal valid manifest", () => {
+    const result = validateManifest(validManifest);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should validate a complete valid manifest", () => {
+    const manifest: MfeManifest = {
+      ...validManifest,
+      description: "Test MFE",
+      framework: "react",
+      dependencies: {
+        "fe:state": "^1.0.0",
+        "fe:routing": "^1.0.0",
+      },
+      permissions: {
+        state: {
+          owns: ["user"],
+          reads: ["app"],
+        },
+      },
+      routes: [
+        {
+          path: "/test",
+          component: "./components/Test.tsx",
+        },
+      ],
+      capabilities: [
+        {
+          id: "test-cap",
+          name: "Test Capability",
+          description: "A test capability",
+        },
+      ],
+    };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should reject non-object manifest", () => {
+    const result = validateManifest("not an object");
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual({
+      field: "manifest",
+      message: "Manifest must be an object",
+      value: "not an object",
+    });
+  });
+
+  it("should reject missing name", () => {
+    const manifest = { ...validManifest };
+    delete (manifest as any).name;
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "name")).toBe(true);
+  });
+
+  it("should reject invalid package name", () => {
+    const manifest = { ...validManifest, name: "invalid-name" };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "name" && e.message.includes("scoped"))).toBe(
+      true
+    );
+  });
+
+  it("should reject missing version", () => {
+    const manifest = { ...validManifest };
+    delete (manifest as any).version;
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "version")).toBe(true);
+  });
+
+  it("should reject invalid version", () => {
+    const manifest = { ...validManifest, version: "not-semver" };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "version")).toBe(true);
+  });
+
+  it("should accept prerelease versions", () => {
+    const manifest = { ...validManifest, version: "1.0.0-alpha.1" };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should accept build metadata in versions", () => {
+    const manifest = { ...validManifest, version: "1.0.0+build.123" };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should reject missing main", () => {
+    const manifest = { ...validManifest };
+    delete (manifest as any).main;
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "main")).toBe(true);
+  });
+
+  it("should reject main without .ts/.tsx extension", () => {
+    const manifest = { ...validManifest, main: "./src/index.js" };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "main" && e.message.includes(".ts"))).toBe(true);
+  });
+
+  it("should accept .tsx main", () => {
+    const manifest = { ...validManifest, main: "./src/index.tsx" };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should reject invalid description type", () => {
+    const manifest = { ...validManifest, description: 123 as any };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "description")).toBe(true);
+  });
+
+  it("should reject non-object dependencies", () => {
+    const manifest = { ...validManifest, dependencies: "invalid" as any };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "dependencies")).toBe(true);
+  });
+
+  it("should reject non-string dependency values", () => {
+    const manifest = {
+      ...validManifest,
+      dependencies: { "fe:state": 123 as any },
+    };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "dependencies.fe:state")).toBe(true);
+  });
+
+  it("should reject non-array routes", () => {
+    const manifest = { ...validManifest, routes: "invalid" as any };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "routes")).toBe(true);
+  });
+
+  it("should reject route without path", () => {
+    const manifest = {
+      ...validManifest,
+      routes: [{ component: "./Test.tsx" } as any],
+    };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "routes[0].path")).toBe(true);
+  });
+
+  it("should reject route without component", () => {
+    const manifest = {
+      ...validManifest,
+      routes: [{ path: "/test" } as any],
+    };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "routes[0].component")).toBe(true);
+  });
+
+  it("should reject non-array capabilities", () => {
+    const manifest = { ...validManifest, capabilities: "invalid" as any };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "capabilities")).toBe(true);
+  });
+
+  it("should reject capability without required fields", () => {
+    const manifest = {
+      ...validManifest,
+      capabilities: [{ id: "test" } as any],
+    };
+
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field.startsWith("capabilities[0]"))).toBe(true);
+  });
+});
+
+describe("assertValidManifest", () => {
+  it("should not throw for valid manifest", () => {
+    const manifest: MfeManifest = {
+      name: "@myorg/my-mfe",
+      version: "1.0.0",
+      main: "./src/index.ts",
+    };
+
+    expect(() => assertValidManifest(manifest)).not.toThrow();
+  });
+
+  it("should throw for invalid manifest", () => {
+    const manifest = { name: "invalid" };
+
+    expect(() => assertValidManifest(manifest)).toThrow("Invalid manifest");
+  });
+
+  it("should include error details in thrown error", () => {
+    const manifest = { name: "invalid" };
+
+    try {
+      assertValidManifest(manifest);
+      expect(true).toBe(false); // Should not reach here
+    } catch (error) {
+      expect((error as Error).message).toContain("name");
+      expect((error as Error).message).toContain("version");
+      expect((error as Error).message).toContain("main");
+    }
+  });
+});

--- a/packages/core/manifest/src/validator.ts
+++ b/packages/core/manifest/src/validator.ts
@@ -1,0 +1,219 @@
+/**
+ * Manifest validator - validates fe.json structure and content
+ */
+
+import type {
+  MfeManifest,
+  ManifestValidationError,
+  ManifestValidationResult,
+} from "./types.ts";
+
+/**
+ * Validate a manifest
+ * @param manifest - Manifest to validate
+ * @returns Validation result with errors
+ */
+export function validateManifest(manifest: unknown): ManifestValidationResult {
+  const errors: ManifestValidationError[] = [];
+
+  if (typeof manifest !== "object" || manifest === null) {
+    errors.push({
+      field: "manifest",
+      message: "Manifest must be an object",
+      value: manifest,
+    });
+    return { valid: false, errors };
+  }
+
+  const m = manifest as Partial<MfeManifest>;
+
+  // Required: name
+  if (typeof m.name !== "string") {
+    errors.push({
+      field: "name",
+      message: "name is required and must be a string",
+      value: m.name,
+    });
+  } else if (!isValidPackageName(m.name)) {
+    errors.push({
+      field: "name",
+      message: "name must be a valid scoped package name (e.g., @org/package)",
+      value: m.name,
+    });
+  }
+
+  // Required: version
+  if (typeof m.version !== "string") {
+    errors.push({
+      field: "version",
+      message: "version is required and must be a string",
+      value: m.version,
+    });
+  } else if (!isValidVersion(m.version)) {
+    errors.push({
+      field: "version",
+      message: "version must be a valid semantic version (e.g., 1.0.0)",
+      value: m.version,
+    });
+  }
+
+  // Required: main
+  if (typeof m.main !== "string") {
+    errors.push({
+      field: "main",
+      message: "main is required and must be a string",
+      value: m.main,
+    });
+  } else if (!m.main.endsWith(".ts") && !m.main.endsWith(".tsx")) {
+    errors.push({
+      field: "main",
+      message: "main must point to a .ts or .tsx file",
+      value: m.main,
+    });
+  }
+
+  // Optional: description
+  if (m.description !== undefined && typeof m.description !== "string") {
+    errors.push({
+      field: "description",
+      message: "description must be a string",
+      value: m.description,
+    });
+  }
+
+  // Optional: framework
+  if (m.framework !== undefined && typeof m.framework !== "string") {
+    errors.push({
+      field: "framework",
+      message: "framework must be a string",
+      value: m.framework,
+    });
+  }
+
+  // Optional: dependencies
+  if (m.dependencies !== undefined) {
+    if (typeof m.dependencies !== "object" || m.dependencies === null) {
+      errors.push({
+        field: "dependencies",
+        message: "dependencies must be an object",
+        value: m.dependencies,
+      });
+    } else {
+      for (const [key, value] of Object.entries(m.dependencies)) {
+        if (typeof value !== "string") {
+          errors.push({
+            field: `dependencies.${key}`,
+            message: "dependency version must be a string",
+            value,
+          });
+        }
+      }
+    }
+  }
+
+  // Optional: permissions
+  if (m.permissions !== undefined) {
+    if (typeof m.permissions !== "object" || m.permissions === null) {
+      errors.push({
+        field: "permissions",
+        message: "permissions must be an object",
+        value: m.permissions,
+      });
+    }
+  }
+
+  // Optional: routes
+  if (m.routes !== undefined) {
+    if (!Array.isArray(m.routes)) {
+      errors.push({
+        field: "routes",
+        message: "routes must be an array",
+        value: m.routes,
+      });
+    } else {
+      m.routes.forEach((route, index) => {
+        if (typeof route.path !== "string") {
+          errors.push({
+            field: `routes[${index}].path`,
+            message: "route path must be a string",
+            value: route.path,
+          });
+        }
+        if (typeof route.component !== "string") {
+          errors.push({
+            field: `routes[${index}].component`,
+            message: "route component must be a string",
+            value: route.component,
+          });
+        }
+      });
+    }
+  }
+
+  // Optional: capabilities
+  if (m.capabilities !== undefined) {
+    if (!Array.isArray(m.capabilities)) {
+      errors.push({
+        field: "capabilities",
+        message: "capabilities must be an array",
+        value: m.capabilities,
+      });
+    } else {
+      m.capabilities.forEach((cap, index) => {
+        if (typeof cap.id !== "string") {
+          errors.push({
+            field: `capabilities[${index}].id`,
+            message: "capability id must be a string",
+            value: cap.id,
+          });
+        }
+        if (typeof cap.name !== "string") {
+          errors.push({
+            field: `capabilities[${index}].name`,
+            message: "capability name must be a string",
+            value: cap.name,
+          });
+        }
+        if (typeof cap.description !== "string") {
+          errors.push({
+            field: `capabilities[${index}].description`,
+            message: "capability description must be a string",
+            value: cap.description,
+          });
+        }
+      });
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Check if a string is a valid scoped package name
+ */
+function isValidPackageName(name: string): boolean {
+  return /^@[a-z0-9-]+\/[a-z0-9-]+$/.test(name);
+}
+
+/**
+ * Check if a string is a valid semantic version
+ */
+function isValidVersion(version: string): boolean {
+  return /^\d+\.\d+\.\d+(-[a-z0-9.-]+)?(\+[a-z0-9.-]+)?$/.test(version);
+}
+
+/**
+ * Assert that a manifest is valid, throwing if not
+ * @param manifest - Manifest to validate
+ * @throws Error with validation errors
+ */
+export function assertValidManifest(manifest: unknown): asserts manifest is MfeManifest {
+  const result = validateManifest(manifest);
+  if (!result.valid) {
+    const errorMessages = result.errors.map((e) => `  - ${e.field}: ${e.message}`).join("\n");
+    throw new Error(`Invalid manifest:\n${errorMessages}`);
+  }
+}

--- a/packages/core/manifest/tsconfig.json
+++ b/packages/core/manifest/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.package.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/core/manifest/tsconfig.test.json
+++ b/packages/core/manifest/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.test.ts"]
+}

--- a/packages/core/preload/README.md
+++ b/packages/core/preload/README.md
@@ -1,0 +1,226 @@
+# @fe/preload
+
+__fePreload runtime for handling dynamic imports in the FE platform.
+
+## Purpose
+
+Provides the `__fePreload` runtime that manages dynamic module loading in the browser. Dynamic `import()` calls are rewritten to `__fePreload()` during build, enabling:
+
+- Module caching
+- Preloading
+- Load tracking
+- Error handling
+
+## Installation
+
+The `__fePreload` runtime must be installed before any MFEs load:
+
+```typescript
+import { installPreloadRuntime } from "@fe/preload";
+
+// Install as global window.__fePreload
+installPreloadRuntime();
+```
+
+## Usage
+
+### Dynamic Imports (Automatic)
+
+During build, dynamic imports are rewritten:
+
+```typescript
+// Source code:
+const module = await import("fe:state");
+
+// Build output:
+const module = await __fePreload("fe:state");
+```
+
+The browser's import map resolves the specifier to a URL.
+
+### Manual Usage
+
+You can also use `__fePreload` directly:
+
+```typescript
+// Load a module
+const state = await window.__fePreload("fe:state");
+
+// Check if loaded
+if (window.__fePreload.isLoaded("fe:state")) {
+  console.log("Already loaded");
+}
+
+// Get module cache
+const cache = window.__fePreload.getCache();
+console.log(`${cache.size} modules in cache`);
+```
+
+### Preloading
+
+Preload modules before they're needed:
+
+```typescript
+// Preload a single module
+await window.__fePreload.preload("fe:@myorg/dashboard");
+
+// Preload with options
+await window.__fePreload.preload("fe:@myorg/dashboard", {
+  timeout: 5000,
+  throwOnError: false,
+  onError: (error, specifier) => {
+    console.error(`Failed to preload ${specifier}:`, error);
+  },
+});
+```
+
+### Batch Preloading
+
+Preload multiple modules at once:
+
+```typescript
+import { batchPreload } from "@fe/preload";
+
+const results = await batchPreload([
+  "fe:@myorg/dashboard",
+  "fe:@myorg/profile",
+  "fe:@myorg/settings",
+]);
+
+results.forEach((result) => {
+  if (result.success) {
+    console.log(`Loaded ${result.specifier}`);
+  } else {
+    console.error(`Failed to load ${result.specifier}:`, result.error);
+  }
+});
+```
+
+### Statistics
+
+Get statistics about loaded modules:
+
+```typescript
+const stats = window.__fePreload.getStats();
+console.log(`Total: ${stats.total}`);
+console.log(`Loaded: ${stats.loaded}`);
+console.log(`Loading: ${stats.loading}`);
+console.log(`Errors: ${stats.errors}`);
+```
+
+### Cache Management
+
+```typescript
+// Clear cache (useful for testing)
+window.__fePreload.clearCache();
+
+// Check cache
+const cache = window.__fePreload.getCache();
+for (const [specifier, entry] of cache) {
+  console.log(`${specifier}: ${entry.state}`);
+}
+```
+
+## Module Cache
+
+Each loaded module is cached with this structure:
+
+```typescript
+interface ModuleCacheEntry {
+  specifier: string;
+  url: string;
+  exports: any;
+  loadedAt: number;
+  state: "loading" | "loaded" | "error";
+  error?: Error;
+}
+```
+
+## Error Handling
+
+### Default Behavior
+
+By default, errors are thrown and can be caught:
+
+```typescript
+try {
+  await window.__fePreload("fe:non-existent");
+} catch (error) {
+  console.error("Failed to load:", error);
+}
+```
+
+### Custom Error Handling
+
+Use the `onError` callback for custom handling:
+
+```typescript
+await window.__fePreload.preload("fe:module", {
+  throwOnError: false,
+  onError: (error, specifier) => {
+    // Log to telemetry
+    telemetry.log("module_load_error", { specifier, error });
+  },
+});
+```
+
+## Timeouts
+
+Preloading supports timeouts to prevent hanging:
+
+```typescript
+await window.__fePreload.preload("fe:module", {
+  timeout: 10000, // 10 seconds
+  throwOnError: true,
+});
+```
+
+Default timeout: 30 seconds
+
+## How It Works
+
+1. **Check cache**: If module is already loaded, return cached exports
+2. **Dedupe loading**: If module is currently loading, return existing promise
+3. **Dynamic import**: Use native `import()` with the specifier
+4. **Import map resolution**: Browser resolves specifier using import map
+5. **Cache result**: Store exports or error in cache
+
+## Integration with Build Pipeline
+
+The build pipeline (Phase 3) will:
+
+1. Parse source code
+2. Find dynamic `import()` calls
+3. Rewrite to `__fePreload()` calls
+4. Inject `__fePreload` script in HTML shell
+
+Example transformation:
+
+```typescript
+// Before
+export async function loadDashboard() {
+  const dashboard = await import("fe:@myorg/dashboard");
+  return dashboard.default;
+}
+
+// After
+export async function loadDashboard() {
+  const dashboard = await __fePreload("fe:@myorg/dashboard");
+  return dashboard.default;
+}
+```
+
+## Browser Compatibility
+
+Requires:
+- ES modules support
+- Import maps support (or polyfill)
+- Dynamic import() support
+
+## Design Principles
+
+1. **Minimal overhead**: Only caches what's loaded
+2. **Deduplication**: Multiple concurrent loads share one promise
+3. **Error isolation**: Failed loads don't crash the app
+4. **Preloading**: Load ahead for better performance
+5. **Observable**: Stats and cache inspection for debugging

--- a/packages/core/preload/package.json
+++ b/packages/core/preload/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@fe/preload",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "bun ../../../scripts/build.ts ./src/index.ts ./dist",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit && tsc --project tsconfig.test.json --noEmit",
+    "lint": "eslint src --ext .ts"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.5",
+    "typescript": "next"
+  }
+}

--- a/packages/core/preload/src/index.ts
+++ b/packages/core/preload/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @fe/preload - __fePreload runtime for dynamic imports
+ *
+ * Provides the __fePreload runtime that handles dynamic imports in the browser.
+ * Dynamic import() calls are rewritten to __fePreload() during build.
+ */
+
+export * from "./types.ts";
+export * from "./runtime.ts";

--- a/packages/core/preload/src/runtime.test.ts
+++ b/packages/core/preload/src/runtime.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { createPreloadRuntime } from "./runtime.ts";
+
+describe("createPreloadRuntime", () => {
+  let __fePreload: ReturnType<typeof createPreloadRuntime>;
+
+  beforeEach(() => {
+    __fePreload = createPreloadRuntime();
+  });
+
+  describe("getCache", () => {
+    it("should return empty cache initially", () => {
+      const cache = __fePreload.getCache();
+      expect(cache.size).toBe(0);
+    });
+  });
+
+  describe("isLoaded", () => {
+    it("should return false for unloaded module", () => {
+      expect(__fePreload.isLoaded("fe:state")).toBe(false);
+    });
+  });
+
+  describe("getStats", () => {
+    it("should return zero stats initially", () => {
+      const stats = __fePreload.getStats();
+      expect(stats).toEqual({
+        total: 0,
+        loaded: 0,
+        loading: 0,
+        errors: 0,
+      });
+    });
+  });
+
+  describe("clearCache", () => {
+    it("should clear the cache", () => {
+      __fePreload.clearCache();
+      const cache = __fePreload.getCache();
+      expect(cache.size).toBe(0);
+    });
+  });
+});
+
+// Note: Full integration tests for __fePreload() would require a browser environment
+// with import maps. These tests verify the API surface and basic functionality.
+describe("__fePreload API", () => {
+  it("should have preload method", () => {
+    const __fePreload = createPreloadRuntime();
+    expect(typeof __fePreload.preload).toBe("function");
+  });
+
+  it("should have getCache method", () => {
+    const __fePreload = createPreloadRuntime();
+    expect(typeof __fePreload.getCache).toBe("function");
+  });
+
+  it("should have isLoaded method", () => {
+    const __fePreload = createPreloadRuntime();
+    expect(typeof __fePreload.isLoaded).toBe("function");
+  });
+
+  it("should have clearCache method", () => {
+    const __fePreload = createPreloadRuntime();
+    expect(typeof __fePreload.clearCache).toBe("function");
+  });
+
+  it("should have getStats method", () => {
+    const __fePreload = createPreloadRuntime();
+    expect(typeof __fePreload.getStats).toBe("function");
+  });
+
+  it("should be callable as a function", () => {
+    const __fePreload = createPreloadRuntime();
+    expect(typeof __fePreload).toBe("function");
+  });
+});

--- a/packages/core/preload/src/runtime.ts
+++ b/packages/core/preload/src/runtime.ts
@@ -1,0 +1,226 @@
+/**
+ * __fePreload runtime implementation
+ * Handles dynamic imports and module preloading
+ */
+
+import type {
+  ModuleCacheEntry,
+  PreloadOptions,
+  PreloadResult,
+  FEPreloadFunction,
+} from "./types.ts";
+
+const DEFAULT_TIMEOUT = 30000; // 30 seconds
+
+/**
+ * Create the __fePreload runtime
+ * @returns __fePreload function
+ */
+export function createPreloadRuntime(): FEPreloadFunction {
+  const moduleCache = new Map<string, ModuleCacheEntry>();
+  const loadingPromises = new Map<string, Promise<any>>();
+
+  /**
+   * Main preload function - dynamically imports a module
+   */
+  async function __fePreload(specifier: string): Promise<any> {
+    // Check cache first
+    const cached = moduleCache.get(specifier);
+    if (cached) {
+      if (cached.state === "loaded") {
+        return cached.exports;
+      }
+      if (cached.state === "error") {
+        throw cached.error;
+      }
+    }
+
+    // Check if already loading
+    if (loadingPromises.has(specifier)) {
+      return loadingPromises.get(specifier);
+    }
+
+    // Start loading
+    const loadPromise = loadModule(specifier);
+    loadingPromises.set(specifier, loadPromise);
+
+    try {
+      const exports = await loadPromise;
+      return exports;
+    } finally {
+      loadingPromises.delete(specifier);
+    }
+  }
+
+  /**
+   * Load a module
+   */
+  async function loadModule(specifier: string): Promise<any> {
+    // Create cache entry
+    const entry: ModuleCacheEntry = {
+      specifier,
+      url: specifier, // Import maps handle resolution
+      exports: null,
+      loadedAt: Date.now(),
+      state: "loading",
+    };
+    moduleCache.set(specifier, entry);
+
+    try {
+      // Use native dynamic import - import maps will resolve the specifier
+      const module = await import(/* @vite-ignore */ specifier);
+
+      entry.exports = module;
+      entry.state = "loaded";
+      entry.loadedAt = Date.now();
+
+      return module;
+    } catch (error) {
+      entry.state = "error";
+      entry.error = error as Error;
+      throw error;
+    }
+  }
+
+  /**
+   * Preload a module without executing it
+   */
+  async function preload(
+    specifier: string,
+    options: PreloadOptions = {}
+  ): Promise<void> {
+    const { timeout = DEFAULT_TIMEOUT, throwOnError = false, onError } = options;
+
+    try {
+      await Promise.race([
+        __fePreload(specifier),
+        createTimeout(timeout, specifier),
+      ]);
+    } catch (error) {
+      if (onError) {
+        onError(error as Error, specifier);
+      }
+      if (throwOnError) {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Get the module cache
+   */
+  function getCache(): Map<string, ModuleCacheEntry> {
+    return new Map(moduleCache);
+  }
+
+  /**
+   * Check if a module is loaded
+   */
+  function isLoaded(specifier: string): boolean {
+    const entry = moduleCache.get(specifier);
+    return entry?.state === "loaded";
+  }
+
+  /**
+   * Clear the module cache
+   */
+  function clearCache(): void {
+    moduleCache.clear();
+    loadingPromises.clear();
+  }
+
+  /**
+   * Get statistics about loaded modules
+   */
+  function getStats() {
+    let loaded = 0;
+    let loading = 0;
+    let errors = 0;
+
+    for (const entry of moduleCache.values()) {
+      if (entry.state === "loaded") loaded++;
+      else if (entry.state === "loading") loading++;
+      else if (entry.state === "error") errors++;
+    }
+
+    return {
+      total: moduleCache.size,
+      loaded,
+      loading,
+      errors,
+    };
+  }
+
+  // Attach methods to the function
+  __fePreload.preload = preload;
+  __fePreload.getCache = getCache;
+  __fePreload.isLoaded = isLoaded;
+  __fePreload.clearCache = clearCache;
+  __fePreload.getStats = getStats;
+
+  return __fePreload as FEPreloadFunction;
+}
+
+/**
+ * Create a timeout promise
+ */
+function createTimeout(ms: number, specifier: string): Promise<never> {
+  return new Promise((_, reject) => {
+    setTimeout(() => {
+      reject(new Error(`Timeout loading module: ${specifier} (${ms}ms)`));
+    }, ms);
+  });
+}
+
+/**
+ * Install __fePreload as global
+ */
+export function installPreloadRuntime(): void {
+  if (typeof window === "undefined") {
+    throw new Error("__fePreload can only be installed in browser environment");
+  }
+
+  if (window.__fePreload) {
+    console.warn("__fePreload already installed");
+    return;
+  }
+
+  window.__fePreload = createPreloadRuntime();
+}
+
+/**
+ * Batch preload multiple modules
+ * @param specifiers - Array of specifiers to preload
+ * @param options - Preload options
+ * @returns Promise resolving to array of results
+ */
+export async function batchPreload(
+  specifiers: string[],
+  options: PreloadOptions = {}
+): Promise<PreloadResult[]> {
+  const results = await Promise.allSettled(
+    specifiers.map(async (specifier) => {
+      try {
+        const exports = await window.__fePreload(specifier);
+        return { success: true, exports, specifier } as PreloadResult;
+      } catch (error) {
+        return {
+          success: false,
+          error: error as Error,
+          specifier,
+        } as PreloadResult;
+      }
+    })
+  );
+
+  return results.map((result) => {
+    if (result.status === "fulfilled") {
+      return result.value;
+    }
+    return {
+      success: false,
+      error: result.reason,
+      specifier: "unknown",
+    };
+  });
+}

--- a/packages/core/preload/src/types.ts
+++ b/packages/core/preload/src/types.ts
@@ -1,0 +1,113 @@
+/**
+ * __fePreload runtime types
+ */
+
+/**
+ * Module cache entry
+ */
+export interface ModuleCacheEntry {
+  /** Module specifier */
+  specifier: string;
+
+  /** Resolved URL */
+  url: string;
+
+  /** Module exports */
+  exports: any;
+
+  /** Load timestamp */
+  loadedAt: number;
+
+  /** Loading state */
+  state: "loading" | "loaded" | "error";
+
+  /** Error if failed to load */
+  error?: Error;
+}
+
+/**
+ * Preload options
+ */
+export interface PreloadOptions {
+  /** Timeout in milliseconds */
+  timeout?: number;
+
+  /** Whether to throw on error */
+  throwOnError?: boolean;
+
+  /** Custom error handler */
+  onError?: (error: Error, specifier: string) => void;
+}
+
+/**
+ * Preload result
+ */
+export interface PreloadResult<T = any> {
+  /** Whether the load was successful */
+  success: boolean;
+
+  /** Module exports (if successful) */
+  exports?: T;
+
+  /** Error (if failed) */
+  error?: Error;
+
+  /** Specifier that was loaded */
+  specifier: string;
+}
+
+/**
+ * Global __fePreload function type
+ */
+export interface FEPreloadFunction {
+  /**
+   * Dynamically import a module
+   * @param specifier - Module specifier (e.g., "fe:state")
+   * @returns Promise resolving to module exports
+   */
+  (specifier: string): Promise<any>;
+
+  /**
+   * Preload a module without executing it
+   * @param specifier - Module specifier
+   * @param options - Preload options
+   */
+  preload(specifier: string, options?: PreloadOptions): Promise<void>;
+
+  /**
+   * Get the module cache
+   */
+  getCache(): Map<string, ModuleCacheEntry>;
+
+  /**
+   * Check if a module is loaded
+   * @param specifier - Module specifier
+   */
+  isLoaded(specifier: string): boolean;
+
+  /**
+   * Clear the module cache
+   */
+  clearCache(): void;
+
+  /**
+   * Get statistics about loaded modules
+   */
+  getStats(): {
+    total: number;
+    loaded: number;
+    loading: number;
+    errors: number;
+  };
+}
+
+/**
+ * Global window extensions
+ */
+declare global {
+  interface Window {
+    __fePreload: FEPreloadFunction;
+  }
+
+  const __fePreload: FEPreloadFunction;
+}

--- a/packages/core/preload/tsconfig.json
+++ b/packages/core/preload/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.package.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/core/preload/tsconfig.test.json
+++ b/packages/core/preload/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src/**/*.test.ts"]
+}

--- a/packages/core/resolver/README.md
+++ b/packages/core/resolver/README.md
@@ -1,0 +1,178 @@
+# @fe/resolver
+
+fe: specifier resolution using import maps.
+
+## Purpose
+
+Resolves `fe:` import specifiers to URLs using import maps. Implements the [WICG Import Maps resolution algorithm](https://github.com/WICG/import-maps#resolution).
+
+Useful for:
+- Build-time resolution during bundling
+- Node.js environments that don't natively support import maps
+- Testing and validation
+
+## Usage
+
+### Creating a Resolver
+
+```typescript
+import { createResolver } from "@fe/resolver";
+import type { ImportMap } from "@fe/import-map";
+
+const importMap: ImportMap = {
+  imports: {
+    "fe:state": "https://cdn.example.com/platform/state/1.0.0/index.js",
+    "fe:@myorg/app": "https://cdn.example.com/mfes/@myorg/app/1.0.0/index.js",
+  },
+};
+
+const resolver = createResolver(importMap);
+```
+
+### Resolving Specifiers
+
+```typescript
+// Resolve a specifier
+const result = resolver.resolve("fe:state");
+console.log(result.url);
+// "https://cdn.example.com/platform/state/1.0.0/index.js"
+
+console.log(result.external);
+// false (it's a fe: specifier)
+```
+
+### Scoped Resolution
+
+```typescript
+const importMap: ImportMap = {
+  imports: {
+    "fe:state": "https://cdn.example.com/platform/state/1.0.0/index.js",
+  },
+  scopes: {
+    "https://cdn.example.com/mfes/@myorg/app/1.0.0/": {
+      "fe:state": "https://cdn.example.com/platform/state/2.0.0/index.js",
+    },
+  },
+};
+
+const resolver = createResolver(importMap);
+
+// Resolve with parent URL to use scoped mapping
+const result = resolver.resolve("fe:state", {
+  parentUrl: "https://cdn.example.com/mfes/@myorg/app/1.0.0/component.js",
+});
+
+console.log(result.url);
+// "https://cdn.example.com/platform/state/2.0.0/index.js" (scoped version)
+```
+
+### Checking if a Specifier Can Be Resolved
+
+```typescript
+if (resolver.canResolve("fe:state")) {
+  console.log("Can resolve fe:state");
+}
+
+if (!resolver.canResolve("unknown-module")) {
+  console.log("Cannot resolve unknown-module");
+}
+```
+
+### Direct Resolution (Without Creating Resolver)
+
+```typescript
+import { resolveSpecifier } from "@fe/resolver";
+
+const result = resolveSpecifier(
+  { importMap },
+  "fe:state",
+  { throwOnUnresolved: true }
+);
+```
+
+### Utility Functions
+
+```typescript
+import { isFESpecifier, extractPackageName } from "@fe/resolver";
+
+// Check if a specifier is a fe: specifier
+if (isFESpecifier("fe:state")) {
+  console.log("This is a fe: specifier");
+}
+
+// Extract package name from fe: specifier
+const packageName = extractPackageName("fe:@myorg/app");
+console.log(packageName);
+// "@myorg/app"
+```
+
+## Resolution Algorithm
+
+The resolver implements the import map resolution algorithm:
+
+1. **Scoped resolution**: If a `parentUrl` is provided, find the most specific matching scope and try to resolve from there
+2. **Top-level resolution**: If not found in scope, try resolving from top-level `imports`
+3. **Prefix matching**: Support trailing-slash mappings (e.g., `lodash/` → `https://cdn.example.com/lodash/`)
+4. **Fallback**: If not found and `throwOnUnresolved` is false, return the specifier as-is
+
+### Most Specific Scope
+
+When multiple scopes match a parent URL, the longest (most specific) scope wins:
+
+```typescript
+const importMap: ImportMap = {
+  scopes: {
+    "https://cdn.example.com/mfes/": { /* ... */ },
+    "https://cdn.example.com/mfes/@myorg/": { /* ... */ },
+    "https://cdn.example.com/mfes/@myorg/app/": { /* ... */ }, // Most specific
+  },
+};
+
+// parentUrl: "https://cdn.example.com/mfes/@myorg/app/component.js"
+// Will use "https://cdn.example.com/mfes/@myorg/app/" scope
+```
+
+## Resolution Result
+
+```typescript
+interface ResolveResult {
+  /** The resolved URL */
+  url: string;
+
+  /** Whether this is an external (non-fe:) specifier */
+  external: boolean;
+
+  /** The original specifier */
+  specifier: string;
+}
+```
+
+## Options
+
+### ResolveOptions
+
+- `parentUrl` - Parent URL for scoped resolution
+- `throwOnUnresolved` - Whether to throw on unresolved specifiers (default: false)
+
+## Error Handling
+
+By default, unresolved specifiers return the original specifier as the URL:
+
+```typescript
+const result = resolver.resolve("unknown");
+// result.url === "unknown"
+```
+
+To throw on unresolved specifiers:
+
+```typescript
+const result = resolver.resolve("unknown", { throwOnUnresolved: true });
+// Throws: "Cannot resolve specifier: unknown"
+```
+
+## Design Principles
+
+1. **Standards-compliant**: Implements WICG import map spec
+2. **Scoped resolution**: Supports per-MFE dependency versions
+3. **Flexible**: Works at build time and runtime
+4. **Type-safe**: Full TypeScript support

--- a/packages/core/resolver/package.json
+++ b/packages/core/resolver/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@fe/resolver",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "bun ../../../scripts/build.ts ./src/index.ts ./dist",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit && tsc --project tsconfig.test.json --noEmit",
+    "lint": "eslint src --ext .ts"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.5",
+    "typescript": "next"
+  }
+}

--- a/packages/core/resolver/src/index.ts
+++ b/packages/core/resolver/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @fe/resolver - fe: specifier resolution
+ *
+ * Resolves import specifiers using import maps.
+ * Implements the WICG import map resolution algorithm.
+ */
+
+export * from "./types.ts";
+export * from "./resolver.ts";

--- a/packages/core/resolver/src/resolver.test.ts
+++ b/packages/core/resolver/src/resolver.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "bun:test";
+import type { ImportMap } from "@fe/import-map";
+import {
+  createResolver,
+  resolveSpecifier,
+  isFESpecifier,
+  extractPackageName,
+} from "./resolver.ts";
+
+describe("resolveSpecifier", () => {
+  it("should resolve from top-level imports", () => {
+    const importMap: ImportMap = {
+      imports: {
+        "fe:state": "https://cdn.example.com/platform/state/1.0.0/index.js",
+        "fe:@myorg/app": "https://cdn.example.com/mfes/@myorg/app/1.0.0/index.js",
+      },
+    };
+
+    const result = resolveSpecifier({ importMap }, "fe:state");
+    expect(result.url).toBe("https://cdn.example.com/platform/state/1.0.0/index.js");
+    expect(result.external).toBe(false);
+  });
+
+  it("should resolve external packages from imports", () => {
+    const importMap: ImportMap = {
+      imports: {
+        react: "https://cdn.example.com/vendor/react/18.2.0/index.js",
+      },
+    };
+
+    const result = resolveSpecifier({ importMap }, "react");
+    expect(result.url).toBe("https://cdn.example.com/vendor/react/18.2.0/index.js");
+    expect(result.external).toBe(true);
+  });
+
+  it("should resolve from scoped imports", () => {
+    const importMap: ImportMap = {
+      imports: {
+        "fe:state": "https://cdn.example.com/platform/state/1.0.0/index.js",
+      },
+      scopes: {
+        "https://cdn.example.com/mfes/@myorg/app/1.0.0/": {
+          "fe:state": "https://cdn.example.com/platform/state/2.0.0/index.js",
+        },
+      },
+    };
+
+    // Without parent URL, should use top-level
+    const result1 = resolveSpecifier({ importMap }, "fe:state");
+    expect(result1.url).toBe("https://cdn.example.com/platform/state/1.0.0/index.js");
+
+    // With matching parent URL, should use scoped
+    const result2 = resolveSpecifier({ importMap }, "fe:state", {
+      parentUrl: "https://cdn.example.com/mfes/@myorg/app/1.0.0/component.js",
+    });
+    expect(result2.url).toBe("https://cdn.example.com/platform/state/2.0.0/index.js");
+  });
+
+  it("should use most specific scope", () => {
+    const importMap: ImportMap = {
+      scopes: {
+        "https://cdn.example.com/mfes/": {
+          "fe:state": "https://cdn.example.com/platform/state/1.0.0/index.js",
+        },
+        "https://cdn.example.com/mfes/@myorg/app/": {
+          "fe:state": "https://cdn.example.com/platform/state/2.0.0/index.js",
+        },
+      },
+    };
+
+    const result = resolveSpecifier({ importMap }, "fe:state", {
+      parentUrl: "https://cdn.example.com/mfes/@myorg/app/component.js",
+    });
+
+    expect(result.url).toBe("https://cdn.example.com/platform/state/2.0.0/index.js");
+  });
+
+  it("should handle prefix matching with trailing slashes", () => {
+    const importMap: ImportMap = {
+      imports: {
+        "lodash/": "https://cdn.example.com/vendor/lodash/4.17.21/",
+      },
+    };
+
+    const result = resolveSpecifier({ importMap }, "lodash/map");
+    expect(result.url).toBe("https://cdn.example.com/vendor/lodash/4.17.21/map");
+  });
+
+  it("should return specifier as-is if not found and throwOnUnresolved is false", () => {
+    const importMap: ImportMap = { imports: {} };
+
+    const result = resolveSpecifier({ importMap }, "unknown");
+    expect(result.url).toBe("unknown");
+  });
+
+  it("should throw if not found and throwOnUnresolved is true", () => {
+    const importMap: ImportMap = { imports: {} };
+
+    expect(() =>
+      resolveSpecifier({ importMap }, "unknown", { throwOnUnresolved: true })
+    ).toThrow("Cannot resolve specifier");
+  });
+});
+
+describe("createResolver", () => {
+  it("should create a resolver with resolve method", () => {
+    const importMap: ImportMap = {
+      imports: {
+        "fe:state": "https://cdn.example.com/platform/state/1.0.0/index.js",
+      },
+    };
+
+    const resolver = createResolver(importMap);
+    const result = resolver.resolve("fe:state");
+
+    expect(result.url).toBe("https://cdn.example.com/platform/state/1.0.0/index.js");
+  });
+
+  it("should create a resolver with canResolve method", () => {
+    const importMap: ImportMap = {
+      imports: {
+        "fe:state": "https://cdn.example.com/platform/state/1.0.0/index.js",
+      },
+    };
+
+    const resolver = createResolver(importMap);
+
+    expect(resolver.canResolve("fe:state")).toBe(true);
+    expect(resolver.canResolve("unknown")).toBe(false);
+  });
+
+  it("should pass options to resolve", () => {
+    const importMap: ImportMap = {
+      scopes: {
+        "https://cdn.example.com/mfes/@myorg/app/": {
+          "fe:state": "https://cdn.example.com/platform/state/2.0.0/index.js",
+        },
+      },
+    };
+
+    const resolver = createResolver(importMap);
+    const result = resolver.resolve("fe:state", {
+      parentUrl: "https://cdn.example.com/mfes/@myorg/app/component.js",
+    });
+
+    expect(result.url).toBe("https://cdn.example.com/platform/state/2.0.0/index.js");
+  });
+});
+
+describe("isFESpecifier", () => {
+  it("should return true for fe: specifiers", () => {
+    expect(isFESpecifier("fe:state")).toBe(true);
+    expect(isFESpecifier("fe:@myorg/app")).toBe(true);
+  });
+
+  it("should return false for non-fe: specifiers", () => {
+    expect(isFESpecifier("react")).toBe(false);
+    expect(isFESpecifier("./relative")).toBe(false);
+    expect(isFESpecifier("https://example.com/module.js")).toBe(false);
+  });
+});
+
+describe("extractPackageName", () => {
+  it("should extract package name from fe: specifier", () => {
+    expect(extractPackageName("fe:state")).toBe("state");
+    expect(extractPackageName("fe:@myorg/app")).toBe("@myorg/app");
+  });
+
+  it("should throw for non-fe: specifiers", () => {
+    expect(() => extractPackageName("react")).toThrow("Not a fe: specifier");
+  });
+});

--- a/packages/core/resolver/src/resolver.ts
+++ b/packages/core/resolver/src/resolver.ts
@@ -1,0 +1,184 @@
+/**
+ * fe: specifier resolver
+ * Resolves import specifiers using import maps
+ */
+
+import type { ImportMap } from "@fe/import-map";
+import type { ResolverContext, ResolveResult, ResolveOptions } from "./types.ts";
+
+/**
+ * Create a resolver with an import map
+ * @param importMap - The import map to use
+ * @param baseUrl - Base URL for resolution
+ * @returns Resolver function
+ */
+export function createResolver(importMap: ImportMap, baseUrl?: string) {
+  const context: ResolverContext = { importMap, baseUrl };
+
+  return {
+    /**
+     * Resolve a specifier to a URL
+     * @param specifier - The specifier to resolve
+     * @param options - Resolution options
+     * @returns Resolution result
+     */
+    resolve(specifier: string, options: ResolveOptions = {}): ResolveResult {
+      return resolveSpecifier(context, specifier, options);
+    },
+
+    /**
+     * Check if a specifier can be resolved
+     * @param specifier - The specifier to check
+     * @param options - Resolution options
+     * @returns true if resolvable
+     */
+    canResolve(specifier: string, options: ResolveOptions = {}): boolean {
+      try {
+        resolveSpecifier(context, specifier, { ...options, throwOnUnresolved: true });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+/**
+ * Resolve a specifier using import map
+ * Implements the import map resolution algorithm
+ */
+export function resolveSpecifier(
+  context: ResolverContext,
+  specifier: string,
+  options: ResolveOptions = {}
+): ResolveResult {
+  const { importMap } = context;
+  const { parentUrl, throwOnUnresolved = false } = options;
+
+  // Try scoped resolution first if we have a parent URL
+  if (parentUrl && importMap.scopes) {
+    const scopeUrl = getScopeUrl(parentUrl, importMap.scopes);
+    if (scopeUrl) {
+      const resolved = resolveFromScope(importMap.scopes[scopeUrl], specifier);
+      if (resolved) {
+        return createResult(specifier, resolved);
+      }
+    }
+  }
+
+  // Try top-level imports
+  if (importMap.imports) {
+    const resolved = resolveFromImports(importMap.imports, specifier);
+    if (resolved) {
+      return createResult(specifier, resolved);
+    }
+  }
+
+  // Not found in import map
+  if (throwOnUnresolved) {
+    throw new Error(`Cannot resolve specifier: ${specifier}`);
+  }
+
+  // Return the specifier as-is (could be a relative/absolute URL)
+  return createResult(specifier, specifier);
+}
+
+/**
+ * Find the most specific scope URL for a parent URL
+ */
+function getScopeUrl(
+  parentUrl: string,
+  scopes: Record<string, Record<string, string>>
+): string | undefined {
+  // Find all matching scopes
+  const matchingScopes = Object.keys(scopes).filter((scope) =>
+    parentUrl.startsWith(scope)
+  );
+
+  if (matchingScopes.length === 0) {
+    return undefined;
+  }
+
+  // Return the longest (most specific) match
+  return matchingScopes.sort((a, b) => b.length - a.length)[0];
+}
+
+/**
+ * Resolve from a scope or imports object
+ */
+function resolveFromImports(
+  imports: Record<string, string>,
+  specifier: string
+): string | undefined {
+  // Exact match
+  if (specifier in imports) {
+    return imports[specifier];
+  }
+
+  // Prefix match (for trailing slash mappings)
+  for (const [key, value] of Object.entries(imports)) {
+    if (key.endsWith("/") && specifier.startsWith(key)) {
+      const suffix = specifier.substring(key.length);
+      return value.endsWith("/") ? value + suffix : value + "/" + suffix;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolve from a scope
+ */
+function resolveFromScope(
+  scope: Record<string, string>,
+  specifier: string
+): string | undefined {
+  return resolveFromImports(scope, specifier);
+}
+
+/**
+ * Create a resolution result
+ */
+function createResult(specifier: string, url: string): ResolveResult {
+  return {
+    specifier,
+    url,
+    external: !specifier.startsWith("fe:"),
+  };
+}
+
+/**
+ * Batch resolve multiple specifiers
+ * @param context - Resolver context
+ * @param specifiers - Array of specifiers to resolve
+ * @param options - Resolution options
+ * @returns Array of resolution results
+ */
+export function resolveMany(
+  context: ResolverContext,
+  specifiers: string[],
+  options: ResolveOptions = {}
+): ResolveResult[] {
+  return specifiers.map((specifier) => resolveSpecifier(context, specifier, options));
+}
+
+/**
+ * Check if a specifier is a fe: specifier
+ * @param specifier - The specifier to check
+ * @returns true if it's a fe: specifier
+ */
+export function isFESpecifier(specifier: string): boolean {
+  return specifier.startsWith("fe:");
+}
+
+/**
+ * Extract package name from fe: specifier
+ * @param specifier - The fe: specifier
+ * @returns Package name without fe: prefix
+ */
+export function extractPackageName(specifier: string): string {
+  if (!isFESpecifier(specifier)) {
+    throw new Error(`Not a fe: specifier: ${specifier}`);
+  }
+  return specifier.substring(3); // Remove "fe:"
+}

--- a/packages/core/resolver/src/types.ts
+++ b/packages/core/resolver/src/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Resolver types for fe: specifier resolution
+ */
+
+import type { ImportMap } from "@fe/import-map";
+
+/**
+ * Resolution context
+ */
+export interface ResolverContext {
+  /** The import map to use for resolution */
+  importMap: ImportMap;
+
+  /** Base URL for relative resolution */
+  baseUrl?: string;
+}
+
+/**
+ * Resolution result
+ */
+export interface ResolveResult {
+  /** The resolved URL */
+  url: string;
+
+  /** Whether this is an external (non-fe:) specifier */
+  external: boolean;
+
+  /** The original specifier */
+  specifier: string;
+}
+
+/**
+ * Resolution options
+ */
+export interface ResolveOptions {
+  /** Parent URL for scoped resolution */
+  parentUrl?: string;
+
+  /** Whether to throw on unresolved specifiers */
+  throwOnUnresolved?: boolean;
+}

--- a/packages/core/resolver/tsconfig.json
+++ b/packages/core/resolver/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.package.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/core/resolver/tsconfig.test.json
+++ b/packages/core/resolver/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.test.ts"]
+}

--- a/schemas/environments.schema.json
+++ b/schemas/environments.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://fe-platform.dev/schemas/environments.json",
+  "title": "FE Platform Environments",
+  "description": "Environment configuration (environments.json)",
+  "type": "object",
+  "required": ["environments"],
+  "properties": {
+    "environments": {
+      "type": "array",
+      "description": "List of deployment environments",
+      "items": {
+        "type": "object",
+        "required": ["name", "url"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Environment name (e.g., dev, staging, production)",
+            "minLength": 1
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Environment base URL"
+          },
+          "cdnUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "CDN URL for assets"
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Custom environment metadata",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/fe.schema.json
+++ b/schemas/fe.schema.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://fe-platform.dev/schemas/fe.json",
+  "title": "FE MFE Manifest",
+  "description": "Micro-frontend manifest (fe.json)",
+  "type": "object",
+  "required": ["name", "version", "main"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "MFE package name (scoped)",
+      "pattern": "^@[a-z0-9-]+/[a-z0-9-]+$"
+    },
+    "version": {
+      "type": "string",
+      "description": "Semantic version",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-[a-z0-9.-]+)?(\\+[a-z0-9.-]+)?$"
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description"
+    },
+    "main": {
+      "type": "string",
+      "description": "Main entry point (must be .ts or .tsx)",
+      "pattern": "\\.(ts|tsx)$"
+    },
+    "framework": {
+      "type": "string",
+      "description": "Framework used (react, vue, svelte, etc.)"
+    },
+    "dependencies": {
+      "type": "object",
+      "description": "Platform package and MFE dependencies",
+      "patternProperties": {
+        "^(fe:|@)": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "permissions": {
+      "type": "object",
+      "description": "Required permissions",
+      "properties": {
+        "state": {
+          "type": "object",
+          "properties": {
+            "owns": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "reads": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        },
+        "network": {
+          "type": "object",
+          "properties": {
+            "domains": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "paths": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        },
+        "storage": {
+          "type": "object",
+          "properties": {
+            "localStorage": { "type": "boolean" },
+            "sessionStorage": { "type": "boolean" },
+            "cookies": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        },
+        "apis": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "routes": {
+      "type": "array",
+      "description": "Routes exposed by this MFE",
+      "items": {
+        "type": "object",
+        "required": ["path", "component"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Route path pattern"
+          },
+          "component": {
+            "type": "string",
+            "description": "Component to render"
+          },
+          "meta": {
+            "type": "object",
+            "description": "Route metadata",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "description": "Capabilities this MFE provides",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "description"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Capability ID"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name"
+          },
+          "description": {
+            "type": "string",
+            "description": "Capability description"
+          },
+          "intents": {
+            "type": "array",
+            "description": "Intent categories",
+            "items": { "type": "string" }
+          },
+          "examples": {
+            "type": "array",
+            "description": "Example invocations",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "ai": {
+      "type": "object",
+      "description": "AI context for catalog",
+      "properties": {
+        "keywords": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "summary": {
+          "type": "string"
+        },
+        "useCases": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "related": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Custom metadata",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/governance.schema.json
+++ b/schemas/governance.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://fe-platform.dev/schemas/governance.json",
+  "title": "FE Platform Governance",
+  "description": "Governance configuration (governance.json)",
+  "type": "object",
+  "properties": {
+    "scoring": {
+      "type": "object",
+      "description": "Governance scoring thresholds",
+      "properties": {
+        "bundleSize": {
+          "type": "object",
+          "description": "Bundle size scoring",
+          "required": ["maxKb", "weight"],
+          "properties": {
+            "maxKb": {
+              "type": "number",
+              "description": "Maximum bundle size in kilobytes",
+              "minimum": 1
+            },
+            "weight": {
+              "type": "number",
+              "description": "Score weight",
+              "minimum": 0,
+              "maximum": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "coverage": {
+          "type": "object",
+          "description": "Code coverage scoring",
+          "required": ["minPercent", "weight"],
+          "properties": {
+            "minPercent": {
+              "type": "number",
+              "description": "Minimum coverage percentage",
+              "minimum": 0,
+              "maximum": 100
+            },
+            "weight": {
+              "type": "number",
+              "description": "Score weight",
+              "minimum": 0,
+              "maximum": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "accessibility": {
+          "type": "object",
+          "description": "Accessibility scoring",
+          "required": ["minScore", "weight"],
+          "properties": {
+            "minScore": {
+              "type": "number",
+              "description": "Minimum accessibility score (0-100)",
+              "minimum": 0,
+              "maximum": 100
+            },
+            "weight": {
+              "type": "number",
+              "description": "Score weight",
+              "minimum": 0,
+              "maximum": 1
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "permissions": {
+      "type": "object",
+      "description": "Permission enforcement settings",
+      "properties": {
+        "allowedScopes": {
+          "type": "array",
+          "description": "Allowed package scopes",
+          "items": {
+            "type": "string",
+            "pattern": "^@[a-z0-9-]+$"
+          }
+        },
+        "checksumVerification": {
+          "type": "boolean",
+          "description": "Enable checksum verification for packages"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/platform.schema.json
+++ b/schemas/platform.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://fe-platform.dev/schemas/platform.json",
+  "title": "FE Platform Configuration",
+  "description": "Core platform configuration (platform.json)",
+  "type": "object",
+  "required": ["name", "version", "org"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Platform name",
+      "minLength": 1
+    },
+    "version": {
+      "type": "string",
+      "description": "Platform version",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-[a-z0-9.-]+)?(\\+[a-z0-9.-]+)?$"
+    },
+    "org": {
+      "type": "string",
+      "description": "Organization identifier",
+      "minLength": 1
+    },
+    "registry": {
+      "type": "object",
+      "description": "Registry configuration",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Registry base URL"
+        },
+        "source": {
+          "type": "string",
+          "format": "uri",
+          "description": "Source registry URL"
+        },
+        "build": {
+          "type": "string",
+          "format": "uri",
+          "description": "Build artifacts URL"
+        }
+      },
+      "required": ["url"]
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/rollout.schema.json
+++ b/schemas/rollout.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://fe-platform.dev/schemas/rollout.json",
+  "title": "FE Platform Rollout State",
+  "description": "Rollout configuration tracking (rollout.json)",
+  "type": "object",
+  "required": ["states"],
+  "properties": {
+    "states": {
+      "type": "array",
+      "description": "Rollout states per MFE and environment",
+      "items": {
+        "type": "object",
+        "required": ["mfeName", "environment", "rolledOut"],
+        "properties": {
+          "mfeName": {
+            "type": "string",
+            "description": "MFE package name",
+            "pattern": "^@[a-z0-9-]+/[a-z0-9-]+$"
+          },
+          "environment": {
+            "type": "string",
+            "description": "Environment name",
+            "minLength": 1
+          },
+          "rolledOut": {
+            "type": "string",
+            "description": "Currently rolled-out version",
+            "pattern": "^\\d+\\.\\d+\\.\\d+(-[a-z0-9.-]+)?(\\+[a-z0-9.-]+)?$"
+          },
+          "rollingOut": {
+            "type": "object",
+            "description": "Version being rolled out (if any)",
+            "required": ["version", "percentage"],
+            "properties": {
+              "version": {
+                "type": "string",
+                "description": "Version being rolled out",
+                "pattern": "^\\d+\\.\\d+\\.\\d+(-[a-z0-9.-]+)?(\\+[a-z0-9.-]+)?$"
+              },
+              "percentage": {
+                "type": "number",
+                "description": "Rollout percentage (0-100)",
+                "minimum": 0,
+                "maximum": 100
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Complete Phase 1 deliverables for FE Platform core runtime:

Core Packages:
- @fe/config: ConfigProvider abstraction with file:// provider
- @fe/manifest: MFE manifest parser and validator
- @fe/import-map: Browser import map generation
- @fe/resolver: fe: specifier resolution (WICG algorithm)
- @fe/preload: __fePreload runtime for dynamic imports

JSON Schemas:
- platform.schema.json: Platform configuration
- environments.schema.json: Environment definitions
- rollout.schema.json: Rollout state tracking
- governance.schema.json: Governance rules
- fe.schema.json: MFE manifest schema

Example:
- Phase 1 interactive demo with HTML shell
- Mock MFE demonstrating fe: specifier loading
- Working import map and __fePreload runtime

Tests: 108 passing across all packages
Exit Criteria: All Phase 1 requirements met