### PR TITLE
Add local module map overrides and Platform DevTools MFE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,18 @@ jobs:
         run: |
           (cd mfe-b && bun install)
           (cd shell && bun install)
+          (cd devtools && bun install)
 
       - name: Type-check
         run: |
           bunx tsc --noEmit --project mfe-a/tsconfig.json
           bunx tsc --noEmit --project mfe-b/tsconfig.json
           bunx tsc --noEmit --project shell/tsconfig.json
+          bunx tsc --noEmit --project devtools/tsconfig.json
 
       - name: Build
         run: |
           (cd mfe-a && bun run build)
           (cd mfe-b && bun run build)
+          (cd devtools && bun run build)
           (cd shell && bun run build)

--- a/cli/src/core/helpers.ts
+++ b/cli/src/core/helpers.ts
@@ -1,6 +1,6 @@
 import { join } from "path";
 import { readFileSync } from "fs";
-import type { ImportMap, PlatformConfig } from "./types";
+import type { PlatformConfig } from "./types";
 
 // --- Paths ---
 
@@ -46,16 +46,3 @@ export function slugFromSpecifier(specifier: string): string {
   return specifier.replace(/^fe\(/, "").replace(/\)$/, "").replace(/^@[^/]+\//, "");
 }
 
-// Generate the browser import map for top-level route MFEs from platform config.
-export function generateRouteImportMap(config: PlatformConfig): ImportMap {
-  const imports: Record<string, string> = {};
-  for (const entry of Object.values(config.routes)) {
-    const { specifier, version } = parseSpecVersion(entry);
-    const pkg = config.packages[specifier];
-    if (!pkg) throw new Error(`Route references unknown package: ${specifier}`);
-    const ver = pkg.versions[version];
-    if (!ver) throw new Error(`Route references unknown version ${version} of ${specifier}`);
-    imports[specifier] = ver.url;
-  }
-  return { imports };
-}

--- a/cli/src/core/types.ts
+++ b/cli/src/core/types.ts
@@ -12,6 +12,7 @@ export interface PackageEntry {
 export interface PlatformConfig {
   routes: Record<string, string>; // path -> "specifier@version"
   packages: Record<string, PackageEntry>;
+  devtools?: string; // "specifier@version" — optional, opt-in per environment
 }
 
 export interface BuildOptions {

--- a/cli/src/plugins/build.ts
+++ b/cli/src/plugins/build.ts
@@ -2,8 +2,8 @@ import { join } from "path";
 import type { Plugin } from "../core/plugin";
 import type { CliContext } from "../core/context";
 import type { Hooks } from "../core/hooks";
-import type { BuildOptions, BuildResult, PlatformConfig } from "../core/types";
-import { readFeDepKeys, generateRouteImportMap } from "../core/helpers";
+import type { BuildOptions, BuildResult } from "../core/types";
+import { readFeDepKeys } from "../core/helpers";
 
 // --- Hook declarations ---
 
@@ -11,7 +11,7 @@ declare module "../core/hooks" {
   interface HookMap {
     "build:before": [target: string, options: BuildOptions];
     "build:after": [target: string, result: BuildResult];
-    "build:shell:before": [config: PlatformConfig];
+    "build:shell:before": [];
     "build:shell:after": [];
   }
 }
@@ -49,9 +49,8 @@ export async function buildTarget(ctx: CliContext, hooks: Hooks, target: string)
 async function buildShell(ctx: CliContext, hooks: Hooks): Promise<void> {
   const dir = join(ctx.root, "shell");
   const config = await ctx.adapters.manifest.read();
-  const importMap = generateRouteImportMap(config);
 
-  await hooks.callHook("build:shell:before", config);
+  await hooks.callHook("build:shell:before");
 
   let options: BuildOptions = {
     entrypoints: [join(dir, "src", "index.ts")],
@@ -71,13 +70,11 @@ async function buildShell(ctx: CliContext, hooks: Hooks): Promise<void> {
     process.exit(1);
   }
 
-  // Inject route import map + platform config into the HTML template.
+  // Inject platform config into the HTML template.
+  // Import maps are no longer static — platform.ts injects them all at runtime.
   const template = await Bun.file(join(dir, "index.html")).text();
-  const importMapTag = `<script type="importmap">\n  ${JSON.stringify(importMap, null, 2)}\n  </script>`;
   const configTag = `<script id="__platform__" type="application/json">\n  ${JSON.stringify(config, null, 2)}\n  </script>`;
-  const html = template
-    .replace("<!-- __IMPORT_MAP__ -->", importMapTag)
-    .replace("<!-- __PLATFORM_CONFIG__ -->", configTag);
+  const html = template.replace("<!-- __PLATFORM_CONFIG__ -->", configTag);
   await Bun.write(join(dir, "dist", "index.html"), html);
 
   await hooks.callHook("build:shell:after");

--- a/cli/src/plugins/dev.ts
+++ b/cli/src/plugins/dev.ts
@@ -16,6 +16,7 @@ declare module "../core/hooks" {
 // --- SSE infrastructure ---
 
 const SSE_PATH = "/__dev";
+const CORS_HEADERS = { "Access-Control-Allow-Origin": "*" };
 const sseClients = new Set<ReadableStreamDefaultController>();
 let pendingTs: number | null = null;
 
@@ -103,17 +104,17 @@ export const devPlugin: Plugin = {
                 cancel() { sseClients.delete(ctrl); },
               });
               return new Response(stream, {
-                headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" },
+                headers: { ...CORS_HEADERS, "Content-Type": "text/event-stream", "Cache-Control": "no-cache" },
               });
             }
 
             if (url.pathname === "/" || url.pathname === "/index.html") {
-              return new Response(sandboxHtml(name), { headers: { "Content-Type": "text/html" } });
+              return new Response(sandboxHtml(name), { headers: { ...CORS_HEADERS, "Content-Type": "text/html" } });
             }
 
             const file = Bun.file(join(distDir, url.pathname));
-            if (await file.exists()) return new Response(file);
-            return new Response("Not found", { status: 404 });
+            if (await file.exists()) return new Response(file, { headers: CORS_HEADERS });
+            return new Response("Not found", { status: 404, headers: CORS_HEADERS });
           },
         });
 

--- a/configs/platform.json
+++ b/configs/platform.json
@@ -2,7 +2,16 @@
   "routes": {
     "/": "fe(@acme/mfe-b)@1.0.0"
   },
+  "devtools": "fe(@acme/devtools)@1.0.0",
   "packages": {
+    "fe(@acme/devtools)": {
+      "versions": {
+        "1.0.0": {
+          "url": "./uploads/devtools/1.0.0/index.js",
+          "deps": {}
+        }
+      }
+    },
     "fe(@acme/mfe-a)": {
       "versions": {
         "1.0.0": {

--- a/devtools/package.json
+++ b/devtools/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "fe(@acme/devtools)",
+  "version": "1.0.0",
+  "module": "src/index.tsx",
+  "types": "src/index.tsx",
+  "scripts": {
+    "build": "bun build src/index.tsx --outdir dist --format esm --target browser"
+  },
+  "dependencies": {
+    "solid-js": "^1.9.0"
+  }
+}

--- a/devtools/src/index.tsx
+++ b/devtools/src/index.tsx
@@ -1,0 +1,287 @@
+import { createSignal, createMemo, For, Show } from "solid-js";
+import { render as solidRender } from "solid-js/web";
+
+// --- Storage keys ---
+
+const OVERRIDES_KEY = "platform:overrides";
+const PANEL_OPEN_KEY = "platform:devtools:open";
+
+// --- Storage helpers ---
+
+function readOverrides(): Record<string, string> {
+  try {
+    return JSON.parse(sessionStorage.getItem(OVERRIDES_KEY) || "{}");
+  } catch {
+    return {};
+  }
+}
+
+function writeOverrides(overrides: Record<string, string>): void {
+  sessionStorage.setItem(OVERRIDES_KEY, JSON.stringify(overrides));
+}
+
+// --- App component ---
+
+function DevTools() {
+  const [overrides, setOverrides] = createSignal(readOverrides());
+  const [open, setOpen] = createSignal(sessionStorage.getItem(PANEL_OPEN_KEY) === "1");
+  const [specInput, setSpecInput] = createSignal("");
+  const [urlInput, setUrlInput] = createSignal("");
+  const [copied, setCopied] = createSignal(false);
+
+  const count = createMemo(() => Object.keys(overrides()).length);
+
+  function togglePanel() {
+    const next = !open();
+    setOpen(next);
+    sessionStorage.setItem(PANEL_OPEN_KEY, next ? "1" : "0");
+  }
+
+  function removeOverride(spec: string) {
+    const next = { ...overrides() };
+    delete next[spec];
+    writeOverrides(next);
+    location.reload();
+  }
+
+  function clearAll() {
+    sessionStorage.removeItem(OVERRIDES_KEY);
+    location.reload();
+  }
+
+  function addOverride() {
+    const spec = specInput().trim();
+    const url = urlInput().trim();
+    if (!spec || !url) return;
+    writeOverrides({ ...overrides(), [spec]: url });
+    location.reload();
+  }
+
+  function share() {
+    const url = new URL(location.href);
+    url.searchParams.set("platform:overrides", JSON.stringify(overrides()));
+    navigator.clipboard.writeText(url.toString()).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  // --- Styles ---
+
+  const btnStyle = createMemo(() => ({
+    position: "fixed" as const,
+    bottom: "16px",
+    right: "16px",
+    "z-index": "2147483647",
+    padding: "8px 14px",
+    "border-radius": "20px",
+    border: "none",
+    background: count() > 0 ? "#d97706" : "#4f46e5",
+    color: "#fff",
+    "font-size": "13px",
+    "font-family": "monospace",
+    "font-weight": "bold",
+    cursor: "pointer",
+    "box-shadow": "0 2px 12px rgba(0,0,0,.35)",
+    "line-height": "1",
+    transition: "background .15s",
+  }));
+
+  const panelStyle: Record<string, string> = {
+    position: "fixed",
+    bottom: "58px",
+    right: "16px",
+    "z-index": "2147483647",
+    width: "420px",
+    "max-height": "80vh",
+    "overflow-y": "auto",
+    background: "#1e1e2e",
+    color: "#cdd6f4",
+    "border-radius": "12px",
+    "box-shadow": "0 8px 32px rgba(0,0,0,.5)",
+    "font-family": "monospace",
+    "font-size": "13px",
+    padding: "0",
+  };
+
+  const headerStyle: Record<string, string> = {
+    display: "flex",
+    "align-items": "center",
+    "justify-content": "space-between",
+    padding: "12px 16px",
+    "border-bottom": "1px solid #313244",
+    "font-weight": "bold",
+    "font-size": "13px",
+    color: "#cba6f7",
+  };
+
+  const sectionStyle: Record<string, string> = {
+    padding: "12px 16px",
+    "border-bottom": "1px solid #313244",
+  };
+
+  const labelStyle: Record<string, string> = {
+    "font-size": "11px",
+    color: "#6c7086",
+    "text-transform": "uppercase",
+    "letter-spacing": "0.06em",
+    "margin-bottom": "8px",
+  };
+
+  const rowStyle: Record<string, string> = {
+    display: "flex",
+    "align-items": "flex-start",
+    gap: "8px",
+    "margin-bottom": "6px",
+    background: "#181825",
+    "border-radius": "6px",
+    padding: "8px 10px",
+  };
+
+  const specStyle: Record<string, string> = {
+    flex: "1",
+    "min-width": "0",
+    "overflow-wrap": "break-word" as const,
+  };
+
+  const specNameStyle: Record<string, string> = {
+    color: "#89b4fa",
+    "font-weight": "bold",
+    "font-size": "12px",
+    "margin-bottom": "2px",
+  };
+
+  const urlTextStyle: Record<string, string> = {
+    color: "#a6e3a1",
+    "font-size": "11px",
+    "word-break": "break-all" as const,
+  };
+
+  const iconBtnStyle: Record<string, string> = {
+    background: "none",
+    border: "none",
+    cursor: "pointer",
+    color: "#6c7086",
+    "font-size": "14px",
+    padding: "0",
+    "line-height": "1",
+    "flex-shrink": "0",
+    "margin-top": "1px",
+  };
+
+  const inputStyle: Record<string, string> = {
+    width: "100%",
+    background: "#181825",
+    border: "1px solid #313244",
+    "border-radius": "6px",
+    color: "#cdd6f4",
+    "font-family": "monospace",
+    "font-size": "12px",
+    padding: "6px 8px",
+    "box-sizing": "border-box" as const,
+    "margin-bottom": "6px",
+  };
+
+  const addBtnStyle: Record<string, string> = {
+    background: "#4f46e5",
+    border: "none",
+    "border-radius": "6px",
+    color: "#fff",
+    "font-family": "monospace",
+    "font-size": "12px",
+    "font-weight": "bold",
+    padding: "6px 12px",
+    cursor: "pointer",
+    width: "100%",
+  };
+
+  const actionsStyle: Record<string, string> = {
+    display: "flex",
+    gap: "8px",
+    padding: "12px 16px",
+  };
+
+  const actionBtnStyle: Record<string, string> = {
+    flex: "1",
+    background: "#313244",
+    border: "none",
+    "border-radius": "6px",
+    color: "#cdd6f4",
+    "font-family": "monospace",
+    "font-size": "12px",
+    padding: "7px 10px",
+    cursor: "pointer",
+  };
+
+  return (
+    <>
+      {/* Toggle button */}
+      <button style={btnStyle()} onClick={togglePanel}>
+        {count() > 0 ? `⚡ ${count()}` : "⚙"}
+      </button>
+
+      {/* Panel */}
+      <Show when={open()}>
+        <div style={panelStyle}>
+          {/* Header */}
+          <div style={headerStyle}>
+            <span>⚙ Platform DevTools</span>
+            <button style={iconBtnStyle} onClick={togglePanel}>✕</button>
+          </div>
+
+          {/* Active overrides */}
+          <div style={sectionStyle}>
+            <div style={labelStyle}>
+              {count() > 0 ? `${count()} active override${count() !== 1 ? "s" : ""}` : "No active overrides"}
+            </div>
+            <For each={Object.entries(overrides())}>
+              {([spec, url]) => (
+                <div style={rowStyle}>
+                  <div style={specStyle}>
+                    <div style={specNameStyle}>{spec}</div>
+                    <div style={urlTextStyle}>{url}</div>
+                  </div>
+                  <button style={iconBtnStyle} title="Remove" onClick={() => removeOverride(spec)}>✕</button>
+                </div>
+              )}
+            </For>
+          </div>
+
+          {/* Add override */}
+          <div style={sectionStyle}>
+            <div style={labelStyle}>Add override</div>
+            <input
+              style={inputStyle}
+              placeholder="fe(@acme/mfe-a)"
+              value={specInput()}
+              onInput={(e) => setSpecInput(e.currentTarget.value)}
+            />
+            <input
+              style={inputStyle}
+              placeholder="http://localhost:3000/index.js"
+              value={urlInput()}
+              onInput={(e) => setUrlInput(e.currentTarget.value)}
+            />
+            <button style={addBtnStyle} onClick={addOverride}>＋ Apply &amp; reload</button>
+          </div>
+
+          {/* Actions */}
+          <div style={actionsStyle}>
+            <Show when={count() > 0}>
+              <button style={actionBtnStyle} onClick={clearAll}>🗑 Clear all</button>
+            </Show>
+            <button style={actionBtnStyle} onClick={share}>
+              {copied() ? "✓ Copied!" : "📋 Share URL"}
+            </button>
+          </div>
+        </div>
+      </Show>
+    </>
+  );
+}
+
+// --- MFE interface ---
+
+export function render(container: HTMLElement, _props: Record<string, unknown>): () => void {
+  return solidRender(() => <DevTools />, container);
+}

--- a/devtools/tsconfig.json
+++ b/devtools/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "lib": ["ES2022", "DOM"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "solid-js"
+  },
+  "include": ["src"]
+}

--- a/shell/index.html
+++ b/shell/index.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Shell</title>
-  <!-- __IMPORT_MAP__ -->
   <!-- __PLATFORM_CONFIG__ -->
 </head>
 <body>

--- a/shell/src/index.ts
+++ b/shell/src/index.ts
@@ -1,7 +1,9 @@
-import { load } from "./platform";
+import { load, loadDevtools } from "./platform";
 
 const app = document.getElementById("app")!;
 const path = window.location.pathname;
+
+await loadDevtools();
 
 const { render } = await load(path);
 render(app, { name: "Shell User" });

--- a/shell/src/platform.ts
+++ b/shell/src/platform.ts
@@ -1,5 +1,6 @@
 // Platform runtime: reads the embedded config, resolves fe() dependency graphs,
 // injects multiple import maps, and dynamically loads route MFEs.
+// Supports per-tab local overrides via sessionStorage for developer workflows.
 
 // --- Types (mirrors cli/src/config.ts for browser use) ---
 
@@ -15,6 +16,7 @@ interface PackageEntry {
 interface PlatformConfig {
   routes: Record<string, string>;
   packages: Record<string, PackageEntry>;
+  devtools?: string;
 }
 
 type RenderFn = (
@@ -57,7 +59,46 @@ function resolveVersion(versions: string[], range: string): string | null {
   return matching[0];
 }
 
+// --- Overrides ---
+
+const OVERRIDES_KEY = "platform:overrides";
+
+function processUrlParams(): void {
+  const params = new URLSearchParams(location.search);
+
+  if (params.has("platform:clear-overrides")) {
+    sessionStorage.removeItem(OVERRIDES_KEY);
+    params.delete("platform:clear-overrides");
+    const qs = params.toString();
+    history.replaceState(null, "", location.pathname + (qs ? "?" + qs : ""));
+    return;
+  }
+
+  const raw = params.get("platform:overrides");
+  if (!raw) return;
+  try {
+    const incoming = JSON.parse(raw) as Record<string, string>;
+    const merged = { ...readOverrides(), ...incoming };
+    sessionStorage.setItem(OVERRIDES_KEY, JSON.stringify(merged));
+  } catch {
+    // ignore malformed param
+  }
+  params.delete("platform:overrides");
+  const qs = params.toString();
+  history.replaceState(null, "", location.pathname + (qs ? "?" + qs : ""));
+}
+
+export function readOverrides(): Record<string, string> {
+  try {
+    return JSON.parse(sessionStorage.getItem(OVERRIDES_KEY) || "{}");
+  } catch {
+    return {};
+  }
+}
+
 // --- Config ---
+
+processUrlParams();
 
 function readConfig(): PlatformConfig {
   const el = document.getElementById("__platform__");
@@ -149,6 +190,20 @@ function injectImportMap(imports: Record<string, string>): void {
   document.head.appendChild(script);
 }
 
+// Apply any active overrides to the resolved dep map, then inject import maps.
+function applyOverridesAndInject(allDeps: Map<string, string>): void {
+  const overrides = readOverrides();
+  for (const [spec, url] of Object.entries(overrides)) {
+    if (allDeps.has(spec)) {
+      console.info(`[platform] override active: ${spec} → ${url}`);
+      allDeps.set(spec, url);
+    }
+  }
+  const imports: Record<string, string> = {};
+  for (const [spec, url] of allDeps) imports[spec] = url;
+  injectImportMap(imports);
+}
+
 // --- Public API ---
 
 export async function load(
@@ -159,18 +214,27 @@ export async function load(
 
   const { specifier, version } = parseSpecVersion(routeEntry);
 
-  // Resolve the full transitive dep graph.
+  // Resolve the full transitive dep graph (including the route MFE itself).
   const allDeps = resolveDeps(specifier, version);
 
-  // Inject import maps for deps (the top-level MFE is already in the default map).
-  const depImports: Record<string, string> = {};
-  for (const [spec, url] of allDeps) {
-    if (spec !== specifier) {
-      depImports[spec] = url;
-    }
-  }
-  injectImportMap(depImports);
+  // Apply overrides and inject all import maps — route MFE included.
+  applyOverridesAndInject(allDeps);
 
-  // Dynamic import — browser resolves via initial map + injected dep maps.
+  // Dynamic import — browser resolves via injected maps.
   return import(specifier);
+}
+
+export async function loadDevtools(): Promise<void> {
+  if (!config.devtools) return;
+
+  const { specifier, version } = parseSpecVersion(config.devtools);
+  const allDeps = resolveDeps(specifier, version);
+  applyOverridesAndInject(allDeps);
+
+  const container = document.createElement("div");
+  container.id = "__devtools__";
+  document.body.appendChild(container);
+
+  const mod = await import(specifier) as { render: RenderFn };
+  mod.render(container, {});
 }


### PR DESCRIPTION
- Override mechanism: platform.ts reads sessionStorage `platform:overrides`
  (specifier → url map) and substitutes local dev URLs before import map
  injection. Activated via ?platform:overrides=<json> URL param, which is
  merged into sessionStorage and stripped from the URL via replaceState.
  Cleared via ?platform:clear-overrides or the DevTools panel.

- Architecture: removed static route import map from shell HTML. platform.ts
  load() now injects all specifiers (route MFE + deps) at runtime, giving
  overrides a uniform injection point for every MFE regardless of position
  in the dep graph.

- DevTools MFE (fe(@acme/devtools)@1.0.0): SolidJS floating panel fixed
  bottom-right. Amber badge with count when overrides active, indigo ⚙
  when idle. Panel lists active overrides with per-entry remove, add-override
  form, share-URL clipboard copy, and clear-all. solid-js bundled into dist
  (not external); all styling inline via SolidJS style prop.

- dev server: all responses now include Access-Control-Allow-Origin: * so
  locally served MFEs can be loaded by a remote shell cross-origin.

- CI: added devtools install, typecheck, and build steps.

https://claude.ai/code/session_01L5xSz2LGMujJ7okYpxRatQ