### PR TITLE
Restructure docs: consolidate README, add CONTRIBUTING guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,11 @@ when a PR merges that implements a plan:
   invariant: no unarchived plan doc exists after its implementing PR lands
   !delete archived docs — they explain why the system is the way it is
   example: externalization-strategy.md, cli-architecture-proposed.md
-pre-PR: update all affected AGENTS.md files, docs/, and README.md to reflect current state before opening any PR
+pre-PR: before opening any PR, update all of the following to reflect current state:
+  - all affected AGENTS.md files
+  - all affected README.md files (root + any subpackage whose interface/purpose changed)
+  - CONTRIBUTING.md — if any workflow, setup step, or development pattern changed
+  - docs/ — archive any plan doc whose implementing PR is landing (add COMPLETED/ARCHIVED header)
 
 ## coding rules
 - source files: max 180 lines · split immediately when exceeded

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing
+
+## Toolchain
+
+**Bun only.** No Node, npm, webpack, Vite, or Rollup. Install [Bun](https://bun.sh) before anything else.
+
+## Setup
+
+```bash
+# Install dependencies for packages that declare them
+cd mfe-b && bun install && cd ..
+cd shell && bun install && cd ..
+cd devtools && bun install && cd ..
+```
+
+## Building and serving the full stack
+
+```bash
+bun cli/src/index.ts build mfe-a
+bun cli/src/index.ts build mfe-b
+bun cli/src/index.ts build devtools
+bun cli/src/index.ts admin upload mfe-a
+bun cli/src/index.ts admin upload mfe-b
+bun cli/src/index.ts admin upload devtools
+# edit configs/platform.json "routes" if needed
+bun cli/src/index.ts build shell
+bun cli/src/index.ts serve
+```
+
+## Developing an MFE in isolation
+
+```bash
+bun cli/src/index.ts dev mfe-a     # sandbox at http://localhost:3000
+```
+
+Edit `src/` — Bun rebuilds, SSE notifies the browser, module swaps in-place. No page reload.
+
+> **Note:** `dev` mode only maps the target MFE in its import map. If the MFE imports other `fe()` packages (e.g. `mfe-b` importing `mfe-a`), those deps won't resolve in the sandbox. Build and upload them first, then use `serve` instead.
+
+## Publishing a new MFE version
+
+```bash
+# 1. Build
+bun cli/src/index.ts build mfe-a
+
+# 2. Upload — registers the artifact in configs/platform.json "packages"
+bun cli/src/index.ts admin upload mfe-a
+# → Uploaded fe(@acme/mfe-a)@1.0.0 → ./uploads/mfe-a/1.0.0/index.js
+
+# 3. Activate — edit configs/platform.json "routes" to point to the new version
+#    "routes": { "/": "fe(@acme/mfe-a)@1.0.0" }
+
+# 4. Rebuild shell to embed the updated config
+bun cli/src/index.ts build shell && bun cli/src/index.ts serve
+```
+
+`admin upload` writes to `packages` only — it never touches `routes`. Artifact publishing and version activation are distinct steps with different access requirements.
+
+## Linking a new `fe()` dependency
+
+The `link` command adds the dep as a `devDependency` with a `file:` URI and runs `bun install`, so TypeScript resolves the import directly via `node_modules` without any `tsconfig` path config:
+
+```bash
+bun cli/src/index.ts link mfe-b mfe-a
+```
+
+For packages in separate repositories, replace `file:../mfe-a` with a git URI manually — nothing else changes:
+
+```json
+"fe(@acme/mfe-a)": "git+https://github.com/org/mfe-a#v1.0.0"
+```
+
+## How `fe()` externalization works
+
+`build.ts` reads `devDependencies` from the target's `package.json` and passes any key starting with `fe(` to `Bun.build`'s `external` option. The naming convention itself is the build signal — no extra config needed.
+
+## Hot reload internals
+
+1. Bun file watcher detects a change in `src/`
+2. Bun rebuilds (typically <100ms)
+3. SSE (`/__dev`) pushes `{ t: timestamp }`
+4. Browser: `unmount()` tears down the current render; `import("/index.js?t=<timestamp>")` loads the fresh module under a new URL (bypasses native module registry cache); `render()` mounts the new version
+
+`pendingTs` on the server holds the latest completed rebuild timestamp. New SSE connections drain it immediately — reconnecting tabs never miss a build.
+
+## Code guidelines
+
+- Source files: max 180 lines — split immediately when exceeded
+- No comments unless logic is genuinely non-obvious; no section headers or doc comments
+- Prefer functions over classes
+- No stubs, mocks, or temporary workarounds — production-ready code only
+- `fe(...)` packages must go in `devDependencies`, not `dependencies` — `build.ts` reads `devDeps`
+- Do not add workspace or monorepo config — this is a plain directory, not an npm workspace
+
+## Pre-PR checklist
+
+Before opening a pull request, update all of the following to reflect the current state:
+
+- [ ] All affected `AGENTS.md` files
+- [ ] All affected `README.md` files (root and any relevant subpackage)
+- [ ] `CONTRIBUTING.md` — if any workflow, setup step, or development pattern changed
+- [ ] `docs/` — archive any plan docs whose implementing PR is landing; add `> **Status:** COMPLETED / ARCHIVED` header and update the title

--- a/README.md
+++ b/README.md
@@ -1,169 +1,74 @@
 <div align="center">
 
-# ⚯ <br /> fe
+# ⚯ fe
 **Ship independently. Compose natively.**
 </div>
 
-## Structure
-
-```
-/                          # Not a npm package — plain directory
-├── mfe-a/                 # Standalone microfrontend
-├── mfe-b/                 # Microfrontend that composes mfe-a
-├── shell/                 # Host app that renders mfe-b
-├── cli/                   # Build, serve, dev, link, and admin commands
-├── configs/
-│   └── platform.json      # Routes + package registry (the deployment config)
-└── uploads/               # Local filesystem "registry" (swap for CDN in production)
-```
+A microfrontend platform built on native browser primitives — ES modules, import maps, and dynamic `import()`. MFEs deploy independently and compose at runtime. Nothing bundles across MFE boundaries.
 
 ## The `fe()` specifier scheme
 
-MFEs import each other using the `fe(@scope/package)` package naming convention:
+Cross-MFE imports use the `fe(@scope/name)` package name convention:
 
 ```ts
 import { render } from "fe(@acme/mfe-a)";
 ```
 
-- **Package names** follow the `fe(@scope/name)` pattern — this is the package `name` field in `package.json`.
-- **At build time**: Bun externalizes all packages whose names start with `fe(` (read from `devDependencies`) — they are not bundled.
-- **At runtime**: The browser resolves `fe(@acme/mfe-a)` to a URL via the injected `<script type="importmap">`.
-- This convention makes federated dependencies universally identifiable: any `fe(...)` import is a cross-MFE boundary.
+`fe(...)` is a plain package name — not a URL scheme. It is the `name` in `package.json`, a bare specifier in `import` statements, and the key in the platform's package registry. Any `fe(...)` import is immediately recognizable as a cross-MFE boundary.
 
-The `fe()` wrapper is a plain package name string, not a URL scheme. Import maps match it as a bare specifier.
+At build time, `fe(...)` imports are externalized — never bundled. At runtime, the browser resolves them via injected import maps.
 
 ## MFE interface
 
-Every MFE exports a single `render` function:
+Every MFE exports one function:
 
 ```ts
 export function render(container: HTMLElement, props: Record<string, unknown>): () => void
 ```
 
-The return value is an **unmount** function for cleanup. No framework coupling.
+The return value unmounts and cleans up. No framework required — pure DOM.
 
-## CLI usage (run from repo root)
+## Packages
 
-```bash
-# Build an MFE or the shell
-bun cli/src/index.ts build mfe-a
-bun cli/src/index.ts build mfe-b
-bun cli/src/index.ts build shell   # also injects import map into HTML
+| | |
+|---|---|
+| `mfe-a/` | Standalone microfrontend (`fe(@acme/mfe-a)`) |
+| `mfe-b/` | Microfrontend that composes `mfe-a` (`fe(@acme/mfe-b)`) |
+| `shell/` | Host app — resolves routes, injects import maps, mounts MFEs |
+| `devtools/` | Developer overlay for per-tab import map overrides (`fe(@acme/devtools)`) |
+| `cli/` | Build, serve, dev, link, and upload tooling |
+| `configs/platform.json` | Routes + package version registry |
 
-# Serve the built shell
-bun cli/src/index.ts serve         # http://localhost:3000
+## CLI
 
-# Dev mode: sandbox + hot reload for a single MFE
-bun cli/src/index.ts dev mfe-a     # http://localhost:3000
+All commands run from the repo root:
 
-# Wire up a fe() dependency between packages (TypeScript + runtime)
-bun cli/src/index.ts link mfe-b mfe-a
+| Command | What it does |
+|---|---|
+| `bun cli/src/index.ts build <target>` | Bundle an MFE or the shell |
+| `bun cli/src/index.ts serve` | Serve the built shell |
+| `bun cli/src/index.ts dev <target>` | Isolated sandbox with hot module replacement |
+| `bun cli/src/index.ts link <consumer> <dep>` | Wire a `fe()` devDependency between packages |
+| `bun cli/src/index.ts admin upload <target>` | Publish a built artifact to the local registry |
 
-# Upload a built MFE to the local registry
-bun cli/src/index.ts admin upload mfe-a
-```
+## Developer experience
 
-## Workflow
+**Isolated development.** `dev` mode runs a standalone sandbox per MFE. Edit `src/` — Bun rebuilds, an SSE message triggers the browser to unmount the old render, import the new module under a cache-busting URL, and call `render()` again in the same container. No page reload. MFE authors have zero awareness of the HMR mechanism.
 
-### Building and running the full stack
+**Independent deployment.** `admin upload` publishes an artifact and registers it in the package registry. Activating it on a route is a separate step — anyone can upload a candidate build; only a privileged actor (CD pipeline or repo access) promotes it by editing `routes` in `configs/platform.json`.
 
-```bash
-bun cli/src/index.ts build mfe-a
-bun cli/src/index.ts build mfe-b
-bun cli/src/index.ts build shell
-bun cli/src/index.ts serve
-```
+**Cross-ecosystem composition.** The package registry accepts full URLs alongside `fe(...)` specifiers, so MFEs hosted on external CDNs compose the same way as local packages.
 
-### Publishing a new version of an MFE
+## Runtime model
 
-```bash
-# 1. Build
-bun cli/src/index.ts build mfe-a
+1. Shell HTML loads with the full platform config embedded as JSON — no static import map
+2. `platform.js` reads the config and resolves the current route to a `specifier@version`
+3. Transitive `fe()` deps are resolved via semver from the packages registry
+4. A `<script type="importmap">` is injected covering all resolved deps
+5. `import(specifier)` — the browser resolves via the injected map and mounts the MFE
 
-# 2. Upload — automatically registers the package version in configs/platform.json
-bun cli/src/index.ts admin upload mfe-a
-# Uploaded fe(@acme/mfe-a)@1.0.0 → ./uploads/mfe-a/1.0.0/index.js
-# (written to platform.json "packages" section; "routes" is not touched)
+Multiple import maps are injected lazily and deduped across navigations.
 
-# 3. Edit configs/platform.json "routes" to activate the new version (or let CD do it):
-#    "routes": { "/": "fe(@acme/mfe-a)@1.0.0" }
+---
 
-# 4. Rebuild shell to inject the updated import map + config, then serve
-bun cli/src/index.ts build shell && bun cli/src/index.ts serve
-```
-
-### Linking a new MFE dependency
-
-The `link` command adds a `devDependency` with a `file:` URI and runs `bun install`,
-so TypeScript resolves the `fe()` import directly from `node_modules` without any
-`tsconfig` paths config:
-
-```bash
-# Make mfe-b depend on mfe-a
-bun cli/src/index.ts link mfe-b mfe-a
-```
-
-For packages in separate repos, swap `file:../mfe-a` for a git URI — nothing else changes:
-
-```json
-"fe(@acme/mfe-a)": "git+https://github.com/org/mfe-a#v1.0.0"
-```
-
-### Developing an MFE in isolation
-
-```bash
-bun cli/src/index.ts dev mfe-a
-# Opens a sandbox at http://localhost:3000 that renders mfe-a standalone.
-# Edit src/ → Bun rebuilds → SSE notifies browser → module swapped in-place.
-# unmount() called on old render, new module imported via ?t= cache-buster, render() called again.
-# No page reload. Reconnecting tabs receive the latest pending rebuild immediately.
-```
-
-## How `fe()` deps are externalized at build time
-
-`build.ts` reads `devDependencies` from each package's `package.json` and externalizes
-any entry whose key starts with `fe(`. This means the package name convention _is_ the
-build signal — no extra config file needed.
-
-```json
-// mfe-b/package.json
-{
-  "devDependencies": {
-    "fe(@acme/mfe-a)": "file:../mfe-a"
-  }
-}
-```
-
-At build time, `fe(@acme/mfe-a)` is left as an external import. At runtime, the browser
-resolves it via the import map injected into `shell/dist/index.html` (generated from `configs/platform.json`).
-
-## Hot reload design
-
-No runtime, no WebSocket, no module graph:
-1. Bun file watcher detects changes in `src/`
-2. Bun rebuilds (typically <100ms)
-3. Server-Sent Events (`/__dev`) push `{ t: timestamp }`
-4. Browser: `unmount()` tears down the current render; `import("/index.js?t=<timestamp>")` loads
-   the fresh module under a new URL (bypassing the native module registry cache);
-   `render()` mounts the new version in the same container. No page reload.
-
-Reconnect safety: the server keeps `pendingTs` — the timestamp of the latest completed rebuild.
-When a tab reconnects after the SSE auto-reconnect gap (~3s), `drainPending()` fires immediately
-on connection so no rebuild is ever missed.
-
-The sandbox HTML (including the `EventSource` wiring) is generated at request time by the CLI's
-dev server and is never written to disk. MFE authors have zero awareness of the HMR mechanism.
-
-## Upload / config separation (intentional design)
-
-The `admin upload` command only **publishes an artifact** and prints its URL.
-It does **not** update `configs/import-map.json`.
-
-This separation is deliberate:
-- **Anyone can upload** a candidate build (no auth needed for artifact storage).
-- **Only a privileged actor** (a CD pipeline, or a human with repo write access)
-  decides which version is active, by editing the `routes` section of `configs/platform.json`.
-- When moving to blob storage (S3, Azure Blob, etc.), TTL policies handle cleanup
-  of unreferenced uploads — no custom cleanup code needed.
-- Auth for uploads can be added later via a `FE_UPLOAD_KEY` env var check in
-  `cli/src/plugins/admin.ts` without changing any other interface.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup, development workflows, and contribution guidelines.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,19 @@
+# cli
+
+Build, serve, dev, link, and admin tooling for the fe platform. All commands run from the repo root:
+
+```bash
+bun cli/src/index.ts <command>
+```
+
+| Command | Description |
+|---|---|
+| `build <target>` | Bundle an MFE or the shell into `dist/` |
+| `serve [port]` | Serve `shell/dist/` with `/uploads/` mounted |
+| `dev <target> [port]` | Isolated sandbox with SSE hot module replacement |
+| `link <consumer> <dep>` | Add a `fe()` devDependency and run `bun install` |
+| `admin upload <target>` | Copy `dist/` to `uploads/` and register in `platform.json` |
+
+Plugin-based architecture — each command is a `Plugin` with `setup(ctx, hooks)`. Storage, manifest management, and building are swappable adapters. Cross-plugin communication goes through a typed hook system (declaration merging extends `HookMap`).
+
+Part of the [fe microfrontend platform](../README.md).

--- a/devtools/README.md
+++ b/devtools/README.md
@@ -1,0 +1,9 @@
+# fe(@acme/devtools)
+
+Developer overlay MFE. Renders a floating panel for managing per-tab import map overrides — swap any `fe()` package's resolved URL without redeploying or restarting anything.
+
+Built with Solid.js (bundled internally — the one exception to the no-framework rule). Loaded by the shell when `config.devtools` is set in `platform.json`. Not published via `routes`; activated by pointing the `devtools` key in the config directly to its artifact URL.
+
+Overrides are stored in `sessionStorage` and applied by the shell's `platform.ts` before import map injection on the next page load. A share button encodes the current overrides as a URL parameter so they can be handed to other tabs or team members.
+
+Part of the [fe microfrontend platform](../README.md).

--- a/mfe-a/README.md
+++ b/mfe-a/README.md
@@ -1,0 +1,15 @@
+# fe(@acme/mfe-a)
+
+Standalone microfrontend — no cross-MFE dependencies.
+
+Exports the standard MFE render interface:
+
+```ts
+export function render(container: HTMLElement, props: Record<string, unknown>): () => void
+```
+
+The return value unmounts and cleans up. No framework — pure DOM.
+
+Used by `mfe-b` as a composed dependency. Demonstrates the simplest possible `fe()` package: a self-contained module that can be developed in isolation, published independently, and composed into larger MFEs without being bundled into them.
+
+Part of the [fe microfrontend platform](../README.md).

--- a/mfe-b/README.md
+++ b/mfe-b/README.md
@@ -1,0 +1,17 @@
+# fe(@acme/mfe-b)
+
+Microfrontend that composes `fe(@acme/mfe-a)`. Demonstrates cross-MFE dependency composition using the `fe()` specifier scheme.
+
+```ts
+import { render as renderA } from "fe(@acme/mfe-a)";  // external — never bundled
+
+export function render(container: HTMLElement, props: Record<string, unknown>): () => void {
+  // renders own chrome, delegates content area to mfe-a
+  const unmountA = renderA(wrapper, props);
+  return () => { unmountA(); wrapper.remove(); };
+}
+```
+
+`mfe-a` is not bundled into `mfe-b`'s output — it stays external at build time and resolves at runtime via the platform's import map injection. Both MFEs unmount cleanly through the returned cleanup function.
+
+Part of the [fe microfrontend platform](../README.md).

--- a/shell/README.md
+++ b/shell/README.md
@@ -1,0 +1,14 @@
+# shell
+
+Host application. Loads the platform config embedded as JSON in the HTML, then at runtime:
+
+1. Resolves the current route to a `specifier@version`
+2. Walks the transitive `fe()` dependency graph via semver
+3. Injects a `<script type="importmap">` covering all resolved packages
+4. Dynamically `import()`s the MFE and calls `render()`
+
+No static import map lives in the HTML. All resolution and injection happens in the browser at load time via `platform.ts`. Multiple import maps can be injected lazily across navigations, deduped by resolved version.
+
+Also loads `devtools` when `config.devtools` is set in `platform.json`, giving developers a floating overlay for per-tab import map overrides without touching the served build.
+
+Part of the [fe microfrontend platform](../README.md).


### PR DESCRIPTION
## Description

Reorganized documentation to improve clarity and maintainability:

- **Root README.md**: Condensed from 169 to 74 lines. Removed verbose structure diagram and workflow examples; kept essential concepts (`fe()` specifier scheme, MFE interface, CLI reference, runtime model). Added high-level platform description.
- **New CONTRIBUTING.md**: Extracted all setup, development workflow, and contribution guidelines from root README. Includes toolchain requirements, build/serve/dev procedures, publishing workflow, linking dependencies, hot reload internals, and code guidelines.
- **New package READMEs**: Added focused docs for `mfe-a/`, `mfe-b/`, `shell/`, `devtools/`, and `cli/` explaining their purpose and role in the platform.
- **Updated AGENTS.md**: Clarified pre-PR checklist to explicitly require updating affected README files (root + subpackages), CONTRIBUTING.md, and docs/ archives.

The root README now serves as a quick reference for the platform's core concepts and CLI. Developers looking for setup or workflow details go to CONTRIBUTING.md. Each package has its own focused README explaining what it does and how it fits into the system.

## Type of Change

- [x] Documentation (docs only)
- [x] Refactor (reorganization for clarity)

## Checklist

- [x] Documentation updated
- [x] All files under 180 lines
- [x] No code changes — documentation restructuring only

## Testing

N/A — documentation only.

## Additional Notes

This is a pure documentation reorganization with no impact on functionality or build behavior. The information is redistributed for better discoverability: quick reference in root README, detailed workflows in CONTRIBUTING.md, package-specific context in subpackage READMEs.

https://claude.ai/code/session_01951tGsi95aoeTv26dW2Ntt