### PR TITLE
docs: improve getting started section based on Gemini critique

### DIFF
--- a/docs/content/getting-started/composing-mfes.md
+++ b/docs/content/getting-started/composing-mfes.md
@@ -32,7 +32,7 @@ Create `mfe-world/package.json`:
 To import from `fe(@myorg/hello)` during development, TypeScript needs to resolve the specifier. `fe link` creates that local resolution without making the packages structurally dependent on each other:
 
 ```bash
-fe link mfe-world mfe-hello
+bunx fe link mfe-world mfe-hello
 ```
 
 This adds `"fe(@myorg/hello)": "file:../mfe-hello"` to `mfe-world`'s `devDependencies` and runs `bun install` inside `mfe-world/`. The result is a symlink at `mfe-world/node_modules/fe(@myorg/hello)` that TypeScript follows. It is a local development convenience. The packages remain independent: `mfe-world` does not bundle `mfe-hello`, does not share its `node_modules`, and does not need to know where `mfe-hello` lives in production. At runtime the browser uses an import map, not this symlink.
@@ -65,7 +65,7 @@ The bare specifier `fe(@myorg/hello)` passes through the build untouched. The ou
 ## Publish the Second MFE
 
 ```bash
-fe publish mfe-world
+bunx fe publish mfe-world
 ```
 
 `fe publish` resolves the `fe(...)` entries in `mfe-world`'s `devDependencies`, records them as semver ranges in the `deps` field of the manifest entry, and registers the full package in `configs/platform.json`. After this, `platform.json` knows that `fe(@myorg/world)@1.0.0` depends on `fe(@myorg/hello)` at `^1.0.0`.
@@ -126,18 +126,20 @@ The `packages` section was written by `fe publish`. The `routes` section is your
 ## Build and Serve
 
 ```bash
-fe build shell
-fe serve
+bunx fe build shell
+bunx fe serve
 ```
 
-`fe build shell` bundles `shell/src/index.ts` into `shell/dist/app.js`, reads `configs/platform.json`, and inlines the full config into `shell/dist/index.html`.
+`bunx fe build shell` bundles `shell/src/index.ts` into `shell/dist/app.js`, reads `configs/platform.json`, and inlines the full config into `shell/dist/index.html`.
 
-`fe serve` starts at `http://localhost:3000`, serving `shell/dist/` and the JIT bundler at `/bundle/`. The runtime resolves `/` to `fe(@myorg/world)@1.0.0`, traces its dependency on `fe(@myorg/hello)`, injects two import maps, and imports `mfe-world`. The browser fetches `mfe-hello` at the moment `mfe-world`'s import executes — not before. Each MFE is its own network request and its own module scope.
+`bunx fe serve` starts at `http://localhost:3000`, serving `shell/dist/` and the JIT bundler at `/bundle/`. Open the browser and watch the network tab. The runtime resolves `/` to `fe(@myorg/world)@1.0.0`, traces its dependency on `fe(@myorg/hello)`, injects two import maps, and imports `mfe-world`. The browser fetches `mfe-hello` at the moment `mfe-world`'s import executes — not before.
+
+Look back at what you wrote. There is no shared `package.json` between the two MFEs. No shared `node_modules`. No build plugin stitching them together. The only thing that connected them was a single line in `configs/platform.json`.
 
 To use a different port:
 
 ```bash
-fe serve 8080
+bunx fe serve 8080
 ```
 
 **Next:** [Architecture Overview](../architecture/overview)

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -58,17 +58,10 @@ Create `configs/platform.json`:
 ## Verify the CLI
 
 ```bash
-./node_modules/.bin/fe
+bunx fe
 ```
 
-You should see the list of available commands. Add `./node_modules/.bin` to your shell `PATH` to use `fe` directly:
-
-```bash
-# add to ~/.bashrc or ~/.zshrc
-export PATH="./node_modules/.bin:$PATH"
-```
-
-All examples in this documentation use `fe` directly. Run all commands from this working directory unless noted otherwise.
+You should see the list of available commands. All examples in this documentation use `bunx fe`. Run all commands from this working directory unless noted otherwise.
 
 ## What You Have Now
 

--- a/docs/content/getting-started/your-first-mfe.md
+++ b/docs/content/getting-started/your-first-mfe.md
@@ -49,30 +49,32 @@ export function render(
 
 ## Preview with the Dev Server
 
-`fe dev` builds the MFE and serves it in an isolated sandbox page:
+`bunx fe dev` builds the MFE and serves it in an isolated sandbox page:
 
 ```bash
-fe dev mfe-hello
+bunx fe dev mfe-hello
 ```
 
-Open `http://localhost:3000`. The sandbox injects a minimal import map that resolves `fe(@myorg/hello)` to the local build, then calls your `render` function on a container element. Edit `src/index.ts` and save: the server rebuilds, sends a reload signal over a Server-Sent Event connection, the browser unmounts the previous instance, and calls `render` again with the updated module.
+Open `http://localhost:3000`. The sandbox injects a minimal import map that resolves `fe(@myorg/hello)` to the local build, then calls your `render` function on a container element. There is no host application, no shell, no shared workspace. This is the MFE running entirely on its own.
+
+Edit `src/index.ts` and save: the server rebuilds, sends a reload signal over a Server-Sent Event connection, the browser unmounts the previous instance, and calls `render` again with the updated module.
 
 To use a different port:
 
 ```bash
-fe dev mfe-hello 4000
+bunx fe dev mfe-hello 4000
 ```
 
-## Publish to the Registry
+## Register the Package
 
-When the MFE is ready to be part of a running shell, publish it:
+When the MFE is ready to ship, register it:
 
 ```bash
-fe publish mfe-hello
+bunx fe publish mfe-hello
 ```
 
 `fe publish` pre-flight type-checks the source, uploads it to the local `sources/` directory, and writes the package entry into `configs/platform.json`. The registered URL points to the JIT bundler (`/bundle/mfe-hello/1.0.0/index.ts`), which compiles the source on the first request and caches the result.
 
-After this step, `mfe-hello` exists in the registry and can be referenced by routes or depended on by other MFEs. It does not yet appear anywhere in the browser — that requires a route, a shell, and `fe serve`, all covered in the next article.
+After this step, `mfe-hello` exists in the registry as an independent, versioned artifact. How and where it appears is a separate concern — covered in the next article.
 
 **Next:** [Composing MFEs](./composing-mfes)


### PR DESCRIPTION
- installation: replace ./node_modules/.bin PATH export with bunx fe;
  removes an anti-pattern and keeps the minimal-tooling narrative intact
- your-first-mfe: switch commands to bunx fe; reframe publish section
  to emphasise the MFE as an independent artifact rather than framing
  it as "ready to be part of a shell"; strengthen dev server copy to
  surface the isolation realization explicitly
- composing-mfes: switch commands to bunx fe; add a closing paragraph
  that prompts the reader to connect the mechanics to the multi-repo
  benefit without stating the conclusion for them

https://claude.ai/code/session_01KLPdRD7CyME81UtDjkxGCU