### PR TITLE
Simplify fe() specifier syntax from fe(@scope/name) to fe(scope/name)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,11 +12,11 @@ CLAUDE.md→symlink→here
 │  └─ runtime/    @fe/runtime  v0.1.0  browser platform loader (published)
 ├─ sandbox/                            example workspace (not published)
 │  ├─ host-app/   name=host-app        shell using @fe/runtime · builds to host-app/dist/
-│  ├─ mfe-a/      name=fe(@acme/mfe-a) standalone MFE · fe()-deps=∅
-│  ├─ mfe-b/      name=fe(@acme/mfe-b) composes mfe-a · devDep→fe(@acme/mfe-a)
+│  ├─ mfe-a/      name=fe(acme/mfe-a) standalone MFE · fe()-deps=∅
+│  ├─ mfe-b/      name=fe(acme/mfe-b) composes mfe-a · devDep→fe(acme/mfe-a)
 │  └─ configs/    fe.config.json · platform.json · routes+packages registry + CLI config
 ├─ toolkit/                            reusable tools and low-dependency MFEs
-│  └─ devtools/   name=fe(@acme/devtools) overlay · uses Solid.js
+│  └─ devtools/   name=fe(acme/devtools) overlay · uses Solid.js
 ├─ nx.json        minimal Nx config (target ordering only · no nx cloud)
 └─ package.json   workspace root
 ```
@@ -29,13 +29,13 @@ tests=∅  CI=typecheck+build (packages job → sandbox job)
 
 ## ⟿ fe() convention
 ```
-fe(@scope/name) = package-name string (NOT url-scheme) = browser bare-specifier
-pkg.json  "name":"fe(@acme/mfe-a)"
-src       import {x} from "fe(@acme/mfe-a)"
+fe(scope/name) = package-name string (NOT url-scheme) = browser bare-specifier
+pkg.json  "name":"fe(acme/mfe-a)"
+src       import {x} from "fe(acme/mfe-a)"
 platform  sandbox/configs/platform.json packages section: specifier → versions → {url, deps}
 ```
 build: build.ts reads pkg.devDeps → filter keys startsWith("fe(") → Bun.build external[]
-ts: bun-install creates node_modules/fe(@acme/mfe-a) symlink → resolves without tsconfig.paths
+ts: bun-install creates node_modules/fe(acme/mfe-a) symlink → resolves without tsconfig.paths
 runtime: browser import maps resolve bare-specifier → JS url (multiple maps, injected lazily)
 
 ## MFE interface (∀ MFE must export)
@@ -91,10 +91,10 @@ Plugins access config via `ctx.adapters.config.get()` — NOT by reading the fil
 ## platform.json config
 ```json
 {
-  "routes": { "/": "fe(@acme/mfe-b)@1.0.0" },
+  "routes": { "/": "fe(acme/mfe-b)@1.0.0" },
   "packages": {
-    "fe(@acme/mfe-a)": { "versions": { "1.0.0": { "url": "...", "deps": {} } } },
-    "fe(@acme/mfe-b)": { "versions": { "1.0.0": { "url": "...", "deps": { "fe(@acme/mfe-a)": "^1.0.0" } } } }
+    "fe(acme/mfe-a)": { "versions": { "1.0.0": { "url": "...", "deps": {} } } },
+    "fe(acme/mfe-b)": { "versions": { "1.0.0": { "url": "...", "deps": { "fe(acme/mfe-a)": "^1.0.0" } } } }
   }
 }
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,10 +43,10 @@ fe build sandbox/mfe-a
 
 # 2. Publish — uploads source for JIT and registers entry in sandbox/configs/platform.json
 fe publish sandbox/mfe-a
-# → Registered fe(@acme/mfe-a)@1.0.0
+# → Registered fe(acme/mfe-a)@1.0.0
 
 # 3. Activate — edit sandbox/configs/platform.json "routes" to point to the new version
-#    "routes": { "/": "fe(@acme/mfe-b)@1.0.0" }
+#    "routes": { "/": "fe(acme/mfe-b)@1.0.0" }
 
 # 4. Rebuild shell to embed the updated config
 fe build shell && fe serve
@@ -65,7 +65,7 @@ fe link sandbox/mfe-b sandbox/mfe-a
 For packages in separate repositories, replace `file:../mfe-a` with a git URI manually — nothing else changes:
 
 ```json
-"fe(@acme/mfe-a)": "git+https://github.com/org/mfe-a#v1.0.0"
+"fe(acme/mfe-a)": "git+https://github.com/org/mfe-a#v1.0.0"
 ```
 
 ## CLI config (`sandbox/configs/fe.config.json`)

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ A microfrontend platform built on native browser primitives — ES modules, impo
 
 At its core, `fe` embraces the browser rather than fighting it. The platform rejects the complexity of distributed bundling in favor of native ES modules and import maps.
 
-1. **Convention over Configuration**: The `fe(@scope/name)` specifier is the universal contract. It's a package name, a bare import specifier, and a registry key.
+1. **Convention over Configuration**: The `fe(scope/name)` specifier is the universal contract. It's a package name, a bare import specifier, and a registry key.
 2. **Build-Time Externalization**: Any `fe()` import is automatically externalized by the bundler. MFEs are built in true isolation.
 3. **Just-In-Time Compilation**: Source code is published to the registry and compiled on-demand at the edge.
 4. **Lazy Resolution**: The browser runtime dynamically resolves dependencies, dedupes versions, and injects import maps exactly when needed.
 
 ## The `fe()` specifier scheme
 
-Cross-MFE imports use the `fe(@scope/name)` package name convention:
+Cross-MFE imports use the `fe(scope/name)` package name convention:
 
 ```ts
-import { render } from "fe(@acme/mfe-a)";
+import { render } from "fe(acme/mfe-a)";
 ```
 
 `fe(...)` is a plain package name — not a URL scheme. It is the `name` in `package.json`, a bare specifier in `import` statements, and the key in the platform's lookup service. Any `fe(...)` import is immediately recognizable as a cross-MFE boundary.
@@ -46,10 +46,10 @@ The return value unmounts and cleans up. Any framework is supported — React, S
 | `packages/runtime/` | Browser runtime — import map injection, semver resolution (`@fe/runtime`) |
 | `packages/compiler/` | Framework-aware MFE bundler + JIT bundler (`@fe/compiler`) |
 | `packages/cli/` | `fe` binary — build, serve, dev, link, publish, check (`@fe/cli`) |
-| `sandbox/mfe-a/` | React MFE (`fe(@acme/mfe-a)`) |
-| `sandbox/mfe-b/` | SolidJS MFE that composes mfe-a (`fe(@acme/mfe-b)`) |
+| `sandbox/mfe-a/` | React MFE (`fe(acme/mfe-a)`) |
+| `sandbox/mfe-b/` | SolidJS MFE that composes mfe-a (`fe(acme/mfe-b)`) |
 | `sandbox/host-app/` | Host app — resolves routes, injects import maps, mounts MFEs |
-| `toolkit/devtools/` | Developer overlay for per-tab import map overrides (`fe(@acme/devtools)`) |
+| `toolkit/devtools/` | Developer overlay for per-tab import map overrides (`fe(acme/devtools)`) |
 | `sandbox/configs/platform.json` | Routes + package version registry |
 | `sandbox/configs/fe.config.json` | CLI config — plugins, artifact paths, shell directory |
 

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -139,7 +139,7 @@ fe check <target|shell>
 readPackageMeta(dir)    → { name, version }  reads dir/package.json
 readFeDepKeys(dir)      → string[]           devDep keys that start with "fe("
 readFeDeps(dir)         → Record<string,string>  full devDeps map filtered to fe() keys
-slugFromSpecifier(name) → string             "fe(@acme/mfe-a)" → "mfe-a"
+slugFromSpecifier(name) → string             "fe(acme/mfe-a)" → "mfe-a"
 ```
 
 ## external plugin loading (plugin-loader.ts)

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -13,7 +13,7 @@ export interface CompileOptions {
 }
 
 export async function compileMfe(options: CompileOptions) {
-  const { entrypoints, outdir, external = ["fe(*)", "fe(@*)"], rootDir, naming } = options;
+  const { entrypoints, outdir, external = ["fe(*)"], rootDir, naming } = options;
 
   let hasSolid = false;
   try {
@@ -51,7 +51,7 @@ export interface JITBundlerOptions {
 type CacheEntry = { js: string };
 
 export function createJITBundler(options: JITBundlerOptions) {
-  const { storage, external = ["fe(*)", "fe(@*)"] } = options;
+  const { storage, external = ["fe(*)"] } = options;
   const cache = new Map<string, CacheEntry>();
 
   async function handle(req: Request): Promise<Response | null> {

--- a/sandbox/configs/AGENTS.md
+++ b/sandbox/configs/AGENTS.md
@@ -27,10 +27,10 @@ To add a CLI plugin: add its npm package name to `plugins[]` and install it in t
 ```json
 {
   "routes": {
-    "/": "fe(@acme/mfe-b)@1.0.0"
+    "/": "fe(acme/mfe-b)@1.0.0"
   },
   "packages": {
-    "fe(@acme/mfe-a)": {
+    "fe(acme/mfe-a)": {
       "versions": {
         "1.0.0": {
           "url": "/bundle/mfe-a/1.0.0/index.ts",
@@ -38,12 +38,12 @@ To add a CLI plugin: add its npm package name to `plugins[]` and install it in t
         }
       }
     },
-    "fe(@acme/mfe-b)": {
+    "fe(acme/mfe-b)": {
       "versions": {
         "1.0.0": {
           "url": "/bundle/mfe-b/1.0.0/index.ts",
           "deps": {
-            "fe(@acme/mfe-a)": "^1.0.0"
+            "fe(acme/mfe-a)": "^1.0.0"
           }
         }
       }
@@ -60,7 +60,7 @@ value = "specifier@version" — the top-level MFE for that route
   resolved by platform.ts at runtime; no static import map in HTML
 
 ### packages
-key   = fe() bare-specifier (exact string in `import … from "fe(@acme/…)"`)
+key   = fe() bare-specifier (exact string in `import … from "fe(acme/…)"`)
 value = { versions: { "X.Y.Z": { url, deps } } }
   url:  runtime URL for the artifact (often built on-the-fly via JIT bundler)
     local JIT: "/bundle/<slug>/<ver>/index.ts"

--- a/sandbox/configs/platform.json
+++ b/sandbox/configs/platform.json
@@ -1,10 +1,10 @@
 {
   "routes": {
-    "/": "fe(@acme/mfe-b)@1.0.0"
+    "/": "fe(acme/mfe-b)@1.0.0"
   },
-  "devtools": "fe(@acme/devtools)@1.0.0",
+  "devtools": "fe(acme/devtools)@1.0.0",
   "packages": {
-    "fe(@acme/devtools)": {
+    "fe(acme/devtools)": {
       "versions": {
         "1.0.0": {
           "url": "./uploads/devtools/1.0.0/index.js",
@@ -12,7 +12,7 @@
         }
       }
     },
-    "fe(@acme/mfe-a)": {
+    "fe(acme/mfe-a)": {
       "versions": {
         "1.0.0": {
           "url": "./uploads/mfe-a/1.0.0/index.js",
@@ -20,12 +20,12 @@
         }
       }
     },
-    "fe(@acme/mfe-b)": {
+    "fe(acme/mfe-b)": {
       "versions": {
         "1.0.0": {
           "url": "./uploads/mfe-b/1.0.0/index.js",
           "deps": {
-            "fe(@acme/mfe-a)": "^1.0.0"
+            "fe(acme/mfe-a)": "^1.0.0"
           }
         }
       }

--- a/sandbox/host-app/AGENTS.md
+++ b/sandbox/host-app/AGENTS.md
@@ -6,8 +6,8 @@
 name:    shell
 version: 1.0.0
 devDependencies:
-  "fe(@acme/mfe-b)": "file:../mfe-b"
-    → node_modules/fe(@acme/mfe-b) symlink (after bun install)
+  "fe(acme/mfe-b)": "file:../mfe-b"
+    → node_modules/fe(acme/mfe-b) symlink (after bun install)
     → no longer statically imported; kept for bun install compatibility
 ```
 
@@ -31,7 +31,7 @@ dist/            build output (gitignored)
 import {load, loadDevtools} from "./platform"
 const app = document.getElementById("app")!
 const path = window.location.pathname
-await loadDevtools()                // loads fe(@acme/devtools) if config.devtools is set
+await loadDevtools()                // loads fe(acme/devtools) if config.devtools is set
 const {render} = await load(path)  // resolves deps, injects import maps, dynamic import
 render(app, {name:"Shell User"})
 ```
@@ -48,7 +48,7 @@ overrides.ts
 
 platform.ts
   readConfig()                  reads <script id="__platform__"> from DOM → PlatformConfig
-  parseSpecVersion(sv)          "fe(@acme/mfe-b)@1.0.0" → {specifier,version}
+  parseSpecVersion(sv)          "fe(acme/mfe-b)@1.0.0" → {specifier,version}
   resolveDeps(spec,ver)         walk transitive fe() dep graph → flat Map<specifier,url>
   injectImportMap(imports)      create+append <script type="importmap"> · deduplicates
   applyOverridesAndInject(deps) merge sessionStorage overrides then injectImportMap

--- a/sandbox/host-app/package.json
+++ b/sandbox/host-app/package.json
@@ -12,7 +12,7 @@
     "@fe/runtime": "workspace:*"
   },
   "devDependencies": {
-    "fe(@acme/mfe-b)": "file:../mfe-b",
+    "fe(acme/mfe-b)": "file:../mfe-b",
     "@fe/cli": "workspace:*"
   }
 }

--- a/sandbox/host-app/tests/host.spec.ts
+++ b/sandbox/host-app/tests/host.spec.ts
@@ -9,16 +9,16 @@ test("platform config is embedded in HTML", async ({ page }) => {
   const configText = await page.locator("#__platform__").textContent();
   const config = JSON.parse(configText!);
 
-  expect(config.routes["/"]).toBe("fe(@acme/mfe-b)@1.0.0");
-  expect(config.packages).toHaveProperty("fe(@acme/mfe-a)");
-  expect(config.packages).toHaveProperty("fe(@acme/mfe-b)");
-  expect(config.packages).toHaveProperty("fe(@acme/devtools)");
+  expect(config.routes["/"]).toBe("fe(acme/mfe-b)@1.0.0");
+  expect(config.packages).toHaveProperty("fe(acme/mfe-a)");
+  expect(config.packages).toHaveProperty("fe(acme/mfe-b)");
+  expect(config.packages).toHaveProperty("fe(acme/devtools)");
 
-  const mfeA = config.packages["fe(@acme/mfe-a)"].versions["1.0.0"];
+  const mfeA = config.packages["fe(acme/mfe-a)"].versions["1.0.0"];
   expect(mfeA.url).toMatch(/mfe-a/);
 
-  const mfeB = config.packages["fe(@acme/mfe-b)"].versions["1.0.0"];
-  expect(mfeB.deps["fe(@acme/mfe-a)"]).toMatch(/^\^/);
+  const mfeB = config.packages["fe(acme/mfe-b)"].versions["1.0.0"];
+  expect(mfeB.deps["fe(acme/mfe-a)"]).toMatch(/^\^/);
 });
 
 test("runtime injects import maps for route dependencies", async ({ page }) => {
@@ -32,8 +32,8 @@ test("runtime injects import maps for route dependencies", async ({ page }) => {
     );
   });
 
-  expect(allSpecifiers).toContain("fe(@acme/mfe-b)");
-  expect(allSpecifiers).toContain("fe(@acme/mfe-a)");
+  expect(allSpecifiers).toContain("fe(acme/mfe-b)");
+  expect(allSpecifiers).toContain("fe(acme/mfe-a)");
 });
 
 test("mfe-b renders and composes mfe-a in #app", async ({ page }) => {
@@ -52,7 +52,7 @@ test("devtools overlay is mounted with toggle button", async ({ page }) => {
 
 test("platform:overrides URL param stores in sessionStorage and is stripped", async ({ page }) => {
   const overrides = {
-    "fe(@acme/mfe-a)": "http://localhost:3000/uploads/mfe-a/1.0.0/index.js",
+    "fe(acme/mfe-a)": "http://localhost:3000/uploads/mfe-a/1.0.0/index.js",
   };
   const qs = new URLSearchParams({ "platform:overrides": JSON.stringify(overrides) });
 
@@ -70,7 +70,7 @@ test("platform:clear-overrides strips sessionStorage and removes URL param", asy
   await page.evaluate(() => {
     sessionStorage.setItem(
       "platform:overrides",
-      JSON.stringify({ "fe(@acme/mfe-a)": "http://custom.example" })
+      JSON.stringify({ "fe(acme/mfe-a)": "http://custom.example" })
     );
   });
 

--- a/sandbox/mfe-a/AGENTS.md
+++ b/sandbox/mfe-a/AGENTS.md
@@ -3,7 +3,7 @@
 
 ## identity
 ```
-name:    fe(@acme/mfe-a)
+name:    fe(acme/mfe-a)
 version: 1.0.0
 module:  src/index.tsx
 framework: React 19 (react-dom/client)
@@ -57,7 +57,7 @@ fe publish sandbox/mfe-a
 ```
 fe dev sandbox/mfe-a
   sandbox at http://localhost:3000
-  importmap: {"imports":{"fe(@acme/mfe-a)":"/index.js"}}
+  importmap: {"imports":{"fe(acme/mfe-a)":"/index.js"}}
   initial render: render(#sandbox,{})
   on src/ change: rebuild → SSE {t:timestamp} → unmount + import("/index.js?t="+t) + re-render
   no page reload · module-swap HMR · reconnecting tabs receive latest pending rebuild

--- a/sandbox/mfe-a/README.md
+++ b/sandbox/mfe-a/README.md
@@ -1,4 +1,4 @@
-# fe(@acme/mfe-a)
+# fe(acme/mfe-a)
 
 React microfrontend — no cross-MFE dependencies.
 

--- a/sandbox/mfe-a/package.json
+++ b/sandbox/mfe-a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fe(@acme/mfe-a)",
+  "name": "fe(acme/mfe-a)",
   "version": "1.0.0",
   "module": "src/index.tsx",
   "scripts": {

--- a/sandbox/mfe-a/project.json
+++ b/sandbox/mfe-a/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "fe(@acme/mfe-a)",
+  "name": "fe(acme/mfe-a)",
   "targets": {
     "typecheck": {}
   }

--- a/sandbox/mfe-b/AGENTS.md
+++ b/sandbox/mfe-b/AGENTS.md
@@ -3,13 +3,13 @@
 
 ## identity
 ```
-name:    fe(@acme/mfe-b)
+name:    fe(acme/mfe-b)
 version: 1.0.0
 module:  src/index.tsx
 framework: SolidJS (solid-js/web)
 devDependencies:
-  "fe(@acme/mfe-a)": "file:../mfe-a"
-    → node_modules/fe(@acme/mfe-a) symlink (after bun install)
+  "fe(acme/mfe-a)": "file:../mfe-a"
+    → node_modules/fe(acme/mfe-a) symlink (after bun install)
     → external at build · importmap at runtime
 ```
 
@@ -19,7 +19,7 @@ jsx=preserve jsxImportSource=solid-js lib=[ES2022,DOM] include=[src]
 
 ## src/index.tsx — full behaviour
 ```tsx
-import { render as renderA } from "fe(@acme/mfe-a)"  // external · resolved via importmap
+import { render as renderA } from "fe(acme/mfe-a)"  // external · resolved via importmap
 import { render as solidRender } from "solid-js/web"
 
 function Wrapper(props:{name?:string;container:HTMLElement})
@@ -44,7 +44,7 @@ Consumers resolve types from `index.d.ts`, not `src/index.tsx`, avoiding Solid J
 fe build sandbox/mfe-b
   → @fe/compiler detects SolidJS (solid-js in package.json)
   → applies bun-plugin-solid (Babel-based JSX transform)
-  → Bun.build(src/index.tsx → dist/index.js, esm, browser, external=["fe(@acme/mfe-a)"])
+  → Bun.build(src/index.tsx → dist/index.js, esm, browser, external=["fe(acme/mfe-a)"])
 
 # direct (from sandbox/mfe-b/):
 bun run build  (calls fe build sandbox/mfe-b via CLI)
@@ -69,12 +69,12 @@ fe publish sandbox/mfe-b
 ```
 fe dev sandbox/mfe-b
   sandbox at http://localhost:3000
-  importmap: {"imports":{"fe(@acme/mfe-b)":"/index.js"}}
+  importmap: {"imports":{"fe(acme/mfe-b)":"/index.js"}}
   initial render: render(#sandbox,{})
   on src/ change: rebuild → SSE {t:timestamp} → unmount + import("/index.js?t="+t) + re-render
   no page reload · module-swap HMR · reconnecting tabs receive latest pending rebuild
 
-  NOTE: dev sandbox only maps fe(@acme/mfe-b) → /index.js
+  NOTE: dev sandbox only maps fe(acme/mfe-b) → /index.js
         mfe-a is NOT in this import map → composing mfe-a will fail at runtime in dev mode
         workaround: publish mfe-a first, then run full shell serve instead of dev
 ```

--- a/sandbox/mfe-b/README.md
+++ b/sandbox/mfe-b/README.md
@@ -1,9 +1,9 @@
-# fe(@acme/mfe-b)
+# fe(acme/mfe-b)
 
-SolidJS microfrontend that composes `fe(@acme/mfe-a)`. Demonstrates cross-MFE dependency composition using the `fe()` specifier scheme with two different frameworks.
+SolidJS microfrontend that composes `fe(acme/mfe-a)`. Demonstrates cross-MFE dependency composition using the `fe()` specifier scheme with two different frameworks.
 
 ```ts
-import { render as renderA } from "fe(@acme/mfe-a)";  // external — never bundled
+import { render as renderA } from "fe(acme/mfe-a)";  // external — never bundled
 ```
 
 Implemented with **SolidJS** (`solid-js/web`). Renders a styled wrapper, then calls into `mfe-a` (a React MFE) to render inside it. Neither MFE knows what framework the other uses — composition happens through the `render()` contract.

--- a/sandbox/mfe-b/package.json
+++ b/sandbox/mfe-b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fe(@acme/mfe-b)",
+  "name": "fe(acme/mfe-b)",
   "version": "1.0.0",
   "module": "src/index.tsx",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "bun-plugin-solid": "^1.0.0",
-    "fe(@acme/mfe-a)": "file:../mfe-a",
+    "fe(acme/mfe-a)": "file:../mfe-a",
     "@fe/cli": "workspace:*"
   },
   "dependencies": {

--- a/sandbox/mfe-b/project.json
+++ b/sandbox/mfe-b/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "fe(@acme/mfe-b)",
+  "name": "fe(acme/mfe-b)",
   "targets": {
     "typecheck": {}
   }

--- a/sandbox/mfe-b/src/index.tsx
+++ b/sandbox/mfe-b/src/index.tsx
@@ -1,4 +1,4 @@
-import { render as renderA } from "fe(@acme/mfe-a)";
+import { render as renderA } from "fe(acme/mfe-a)";
 import { render as solidRender } from "solid-js/web";
 
 function Wrapper(props: { name?: string; container: HTMLElement }) {

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@fe/cli": "workspace:*",
-    "fe(@acme/mfe-b)": "file:./mfe-b"
+    "fe(acme/mfe-b)": "file:./mfe-b"
   }
 }

--- a/toolkit/devtools/AGENTS.md
+++ b/toolkit/devtools/AGENTS.md
@@ -3,7 +3,7 @@
 
 ## identity
 ```
-name:    fe(@acme/devtools)
+name:    fe(acme/devtools)
 version: 1.0.0
 module:  src/index.tsx
 types:   src/index.tsx
@@ -100,7 +100,7 @@ fe admin upload devtools
 
 # activate: add to platform.json manually:
 {
-  "devtools": "fe(@acme/devtools)@1.0.0",
+  "devtools": "fe(acme/devtools)@1.0.0",
   "routes": { ... },
   "packages": { ... }
 }

--- a/toolkit/devtools/README.md
+++ b/toolkit/devtools/README.md
@@ -1,4 +1,4 @@
-# fe(@acme/devtools)
+# fe(acme/devtools)
 
 Developer overlay MFE. Renders a floating panel for managing per-tab import map overrides — swap any `fe()` package's resolved URL without redeploying or restarting anything.
 

--- a/toolkit/devtools/package.json
+++ b/toolkit/devtools/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fe(@acme/devtools)",
+  "name": "fe(acme/devtools)",
   "version": "1.0.0",
   "module": "src/index.tsx",
   "types": "src/index.tsx",

--- a/toolkit/devtools/project.json
+++ b/toolkit/devtools/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "fe(@acme/devtools)",
+  "name": "fe(acme/devtools)",
   "targets": {
     "typecheck": {}
   }

--- a/toolkit/devtools/src/index.tsx
+++ b/toolkit/devtools/src/index.tsx
@@ -118,7 +118,7 @@ function DevTools() {
             <div style={labelStyle}>Add override</div>
             <input
               style={inputStyle}
-              placeholder="fe(@acme/mfe-a)"
+              placeholder="fe(acme/mfe-a)"
               value={specInput()}
               onInput={(e) => setSpecInput(e.currentTarget.value)}
             />


### PR DESCRIPTION
## Description

Remove the `@` symbol from the `fe()` specifier convention throughout the codebase. The specifier syntax is simplified from `fe(@scope/name)` to `fe(scope/name)`, making it more concise while maintaining the same functionality as a bare import specifier and package name.

This change affects:
- All MFE package names and imports across the sandbox
- Platform configuration and registry entries
- Test expectations and documentation
- External bundle configuration patterns
- Developer-facing examples and comments

## Type of Change

- [ ] Feature (new capability)
- [x] Refactor (code restructuring)
- [x] Test (adding or updating tests)
- [x] Documentation (docs only)
- [ ] Chore (maintenance)

## Related Issues

N/A

## Checklist

- [x] Code follows project naming conventions
- [x] All files are under 180 lines
- [x] Tests added/updated and passing
- [x] TypeScript checks pass
- [x] Linting passes
- [x] Build succeeds
- [x] Documentation updated if needed
- [x] Plugin-first approach used where applicable

## Testing

Updated test expectations in `sandbox/host-app/tests/host.spec.ts` to verify the new specifier format is correctly embedded in platform config and resolved at runtime. All existing tests pass with the simplified syntax.

## Additional Notes

This is a convention-level change that simplifies the `fe()` specifier scheme without altering the underlying platform mechanics. The specifier remains a plain package name, bare import specifier, and registry key — just with cleaner syntax.

https://claude.ai/code/session_01QxDR9H8xgPWETwGiWGTvVR